### PR TITLE
Change PORT for running locally

### DIFF
--- a/preview/server.js
+++ b/preview/server.js
@@ -8,7 +8,7 @@ const app = express();
 const templates = require('./src/js/lib/templates');
 const template = require('./src/js/lib/template');
 
-app.set('port', (process.env.PORT || 9000));
+app.set('port', (process.env.PORT || 7000));
 
 app.use(bodyParser.json());
 

--- a/preview/src/js/lib/messenger.js
+++ b/preview/src/js/lib/messenger.js
@@ -30,7 +30,7 @@ function onMessage(event) {
 	});
 
 	function respond(error, result) {
-		event.source.postMessage(JSON.stringify({ id: data.id, error: error, result: result }), 'http://localhost:9000');
+		event.source.postMessage(JSON.stringify({ id: data.id, error: error, result: result }), 'http://localhost:7000');
 	}
 }
 

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -150,5 +150,5 @@ function generateId() {
 function post(id, iframeId, type, value) {
     // TODO Allow localhost:9000 when developing
     // and m.code.dev-theguardian.com when testing
-    window.top.postMessage(JSON.stringify({ id, iframeId, type, value }), location.protocol + (devMode === 'true' ? '//localhost:9000' : '//www.theguardian.com'));
+    window.top.postMessage(JSON.stringify({ id, iframeId, type, value }), location.protocol + (devMode === 'true' ? '//localhost:7000' : '//www.theguardian.com'));
 }


### PR DESCRIPTION
Some components may require that we simultaneously run frontend, which also runs on port 9000. Changing this repository is much easier than frontend :)

@regiskuckaertz, looking [here](https://github.com/guardian/commercial-templates/blob/jn-switch-preview-port/src/_shared/js/messages.js#L153) could we not remove the need for `DevMode` by just using `location.port`?