### PR TITLE
Provide a method to clear the build directory

### DIFF
--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,20 @@
+const rimraf = require('rimraf');
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+
+const targetToClean = './build';
+
+console.log('Time to clean...');
+clean()
+console.log('... all done!');
+
+function clean() {
+  fs.readdirSync(targetToClean)
+      .filter(file => { return !file.startsWith('.'); })
+      .forEach( (file, index) => {
+        console.log('Removing ' + file + '...');
+        rimraf(targetToClean +'/' + file, {}, err => {
+          if (err) return console.error(err)
+        });
+      });
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node-sass": "^3.8.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
+    "rimraf": "^2.5.4",
     "rollup": "^0.34.1",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^4.1.0",
@@ -31,6 +32,7 @@
   },
   "scripts": {
     "build": "node build.js",
+    "clean": "node clean.js",
     "serve-preview": "nodemon preview/server.js",
     "build-preview": "node preview/build.js"
   },


### PR DESCRIPTION
If the `build` task fails, then it fails silently. Instead of fixing that, I just wrote a `clean` task that can be run before running `build`, thus making it obvious when the build fails - i.e. an empty target folder - rather than having the old files squatting there and deceiving you into thinking it has correctly built.