### PR TITLE
Provide method for altering the port for running with frontend.

### DIFF
--- a/src/_shared/js/dev.js
+++ b/src/_shared/js/dev.js
@@ -1,0 +1,4 @@
+// necessary when running multiple local services and making CORS requests
+export function portify(host, target = '9000') {
+  return host.replace('7000', target);
+}


### PR DESCRIPTION
It didn't really seem to fit anywhere, so I created `dev.js`. This can be used to wrap any uses of `host` to fetch from frontend.