### PR TITLE
Add CORS instructions for testing preview locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,20 @@ You can modify variables in `test.json` while the server is running, and reload 
 
 **Note:** if the preview section cuts off part of the ad once it's selected, resizing the window or opening the dev tools should cause the page to redraw and fix the problem.
 
-## Testing on Frontend
+# Testing on Frontend (Local)
+If a native component is to make requests to a frontend endpoint, then both preview and frontend will need to be run simultaneously.
+This will require you to use:
+
+- the [`portify`](https://github.com/guardian/commercial-templates/blob/master/src/_shared/js/dev.js) method in `src/_shared/js/dev.js` to programmatically switch between 7000 and 9000 when making outbound requests.
+- the [`JsonComponent`](https://github.com/guardian/frontend/blob/master/common/app/common/JsonComponent.scala) method to serve the JSON response from the frontend controller. This method wraps the JSON response in a [CORS](https://github.com/guardian/frontend/blob/master/common/app/model/Cors.scala) header which allows cross-origin requests from a whitelist of origins specified in...
+- the [`frontend.conf`]('~/.gu/frontend.conf') overrides as such:
+```
+devOverrides {
+        ajax.cors.origin="http://localhost:7000"
+}
+```
+
+## Testing on Frontend (Prod)
 
 There will shortly be an easier way to preview, but for now:
 
@@ -51,4 +64,3 @@ There will shortly be an easier way to preview, but for now:
 ## Useful Info
 
 - DFP variables can be used in JS strings, because the `index.js` file gets minified and attached to the bottom of the page during the build process.
-


### PR DESCRIPTION
Thought this might be useful for testing components that are built dynamically and which require running frontend.