### PR TITLE
Removes buggy use of DFP variable in  and uses parameters for API query.

### DIFF
--- a/preview/src/js/components/Preview.js
+++ b/preview/src/js/components/Preview.js
@@ -3,7 +3,7 @@ const React = require('react');
 module.exports = React.createClass({
     componentDidMount: function() {
         let iframe = this.refs.iframe.getDOMNode();
-        iframe.onload = () => iframe.contentWindow.postMessage(JSON.stringify({ id: 'test', host: 'http://localhost:7000' }), 'http://localhost:7000');
+        iframe.onload = () => iframe.contentWindow.postMessage(JSON.stringify({ id: 'test', host: 'http://localhost:7000', preview: 'true'}), 'http://localhost:7000');
     },
 
     render: function () {

--- a/src/_shared/js/config.js
+++ b/src/_shared/js/config.js
@@ -1,7 +1,8 @@
 export default {
+    apiBaseUrl: 'https://api.nextgen.guardianapps.co.uk',
     travelUrl: '/commercial/travel/api/offers.json',
     booksUrl: '/commercial/books/api/books.json',
     capiSingleUrl: 'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json',
     jobsUrl: '/commercial/jobs/api/jobs.json',
-    soulmatesUrl: 'https://api.nextgen.guardianapps.co.uk/commercial/api/soulmates.json'
+    soulmatesUrl: 'commercial/api/soulmates.json'
 }

--- a/src/_shared/js/config.js
+++ b/src/_shared/js/config.js
@@ -3,5 +3,5 @@ export default {
     booksUrl: '/commercial/books/api/books.json',
     capiSingleUrl: 'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json',
     jobsUrl: '/commercial/jobs/api/jobs.json',
-    soulmatesUrl: '/commercial/soulmates/api/[%SubFeed%].json'
+    soulmatesUrl: 'https://api.nextgen.guardianapps.co.uk/commercial/api/soulmates.json'
 }

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -19,7 +19,7 @@ export function getIframeId() {
             } catch(_) { return; }
 
             const keys = Object.keys(json);
-            if( keys.length !== 2 || !keys.includes('id') || !keys.includes('host') ) return;
+            if( keys.length !== 3 || !keys.includes('id') || !keys.includes('host') ) return;
 
             self.removeEventListener('message', onMessage);
             ({ id: iframeId, host: parentOrigin } = json);

--- a/src/soulmates/index.js
+++ b/src/soulmates/index.js
@@ -3,10 +3,13 @@ import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/mess
 import { write } from '../_shared/js/dom';
 import { portify } from '../_shared/js/dev';
 
+const params = new URLSearchParams();
+params.append('t', '[%SubFeed%]');
+
 const cardContainer = document.getElementsByClassName("adverts__row")[0];
 
 getIframeId()
-  .then(({host}) => fetch(`${portify(host)}${config.soulmatesUrl}`))
+  .then(({host}) => fetch(`${portify(host)}${config.soulmatesUrl}?${params}`))
   .then(response => response.json())
   .then(soulmates => soulmates.map(createSoulmateCard))
   .then(cards => Promise.all([addSoulmatesCards(cards), getWebfonts()]))

--- a/src/soulmates/index.js
+++ b/src/soulmates/index.js
@@ -7,13 +7,23 @@ const params = new URLSearchParams();
 params.append('t', '[%SubFeed%]');
 
 const cardContainer = document.getElementsByClassName("adverts__row")[0];
-
 getIframeId()
-  .then(({host}) => fetch(`${portify(host)}${config.soulmatesUrl}?${params}`))
+  .then(json => fetch(`${deriveEndpoint(json.host, json.preview)}?${params}`))
   .then(response => response.json())
   .then(soulmates => soulmates.map(createSoulmateCard))
   .then(cards => Promise.all([addSoulmatesCards(cards), getWebfonts()]))
   .then(resizeIframeHeight);
+
+/*  The PROD endpoint for Soulmates is not on theguardian.com, so we must detect
+    whether we are in DEV or PROD before supplying the full endpoint */
+function deriveEndpoint(host, isPreview) {
+  if (isPreview)
+    host = portify(host);
+  else
+    host = config.apiBaseUrl;
+
+  return `${host}/${config.soulmatesUrl}`;
+}
 
 function createSoulmateCard(soulmate, index) {
 


### PR DESCRIPTION
This PR accomplishes two things

1) Removes the reference to `[%SubFeed%]` in `config.js`, which otherwise causes DFP to freak out when rendering anything other than Soulmates.

2) Makes the querying of `frontend` JSON endpoints consistent by using parameters rather than inspecting the path. Inspecting the path was probably slightly more straightforward but... CONSISTENCY.


@Ap0c 