### PR TITLE
CAPI Merchandising Single - Supported Template

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "nodemon": "^1.10.2",
     "sass-mq": "^3.2.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "nodemon": "^1.10.2",
     "sass-mq": "^3.2.9"
   },
   "devDependencies": {

--- a/src/_shared/js/images.js
+++ b/src/_shared/js/images.js
@@ -18,7 +18,7 @@ export function addSourceset(responseJson) {
 
     srcsetFragment.appendChild(highDef);
     srcsetFragment.appendChild(lowDef);
-  };
+  });
     return srcsetFragment;
 }
 

--- a/src/_shared/js/images.js
+++ b/src/_shared/js/images.js
@@ -1,0 +1,42 @@
+export function addSourceset(responseJson) {
+
+  let srcsetFragment = document.createDocumentFragment();
+
+  responseJson.forEach(source => {
+
+    let highDef = document.createElement('source');
+    highDef.media = `(min-width: ${source.minWidth}px) and
+    (-webkit-min-device-pixel-ratio: 1.25),
+    (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`;
+    highDef.sizes = source.sizes;
+    highDef.srcset = `${window.location.protocol}${source.highDefSrcset}`;
+
+    let lowDef = document.createElement('source');
+    lowDef.media = `(min-width: ${source.minWidth}px)`;
+    lowDef.sizes = source.sizes;
+    lowDef.srcset = `${window.location.protocol}${source.lowDefSrcset}`;
+
+    srcsetFragment.appendChild(highDef);
+    srcsetFragment.appendChild(lowDef);
+  };
+    return srcsetFragment;
+}
+
+export function insertBetweenComments(sources) {
+
+	let pictures = Array.from(document.getElementsByTagName('picture'));
+
+  return write(() => {
+		pictures.forEach((picture, index) => picture.insertBefore(sources[index], picture.firstChild));
+	});
+}
+
+export function checkIcon(responseJson) {
+    return responseJson.audioTag ?
+        audioIcon :
+    responseJson.galleryTag ?
+        imageIcon :
+    responseJson.videoTag ?
+        videoIcon :
+        '';
+}

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -18,7 +18,7 @@ if (customUrl !== '') {
 
 enableToggles();
 getIframeId()
-.then(() => fetch(`${config.capiSingleUrl}?${params}`))
+.then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
 .then(capiData => [addSourceset(capiData.articleImage.sources), populateCard(capiData)])
 .then(([sources, html]) => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]).then(() => insertBetweenComments(sources)))

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -1,8 +1,6 @@
-import config from '../_shared/js/config';
 import { enableToggles } from '../_shared/js/ui.js';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
-import { portify } from '../_shared/js/dev';
 import { addSourceset, insertBetweenComments, checkIcon } from '../_shared/js/images.js';
 
 let container = document.getElementsByClassName('adverts__body')[0];

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -3,6 +3,7 @@ import { enableToggles } from '../_shared/js/ui.js';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
 import { portify } from '../_shared/js/dev';
+import { addSourceset, insertBetweenComments, checkIcon } from '../_shared/js/images.js';
 
 let container = document.getElementsByClassName('adverts__body')[0];
 let params = new URLSearchParams();
@@ -57,48 +58,4 @@ function populateCard(responseJson) {
         <img class="adverts__badge__logo" src="${getValue('[%BrandLogo%]', responseJson.branding.sponsorLogo.url)}" alt="">
       </a>
     </div>`;
-}
-
-function checkIcon(responseJson) {
-    return responseJson.audioTag ?
-        audioIcon :
-    responseJson.galleryTag ?
-        imageIcon :
-    responseJson.videoTag ?
-        videoIcon :
-        '';
-}
-
-function addSourceset(responseJson) {
-
-  let srcsetFragment = document.createDocumentFragment();
-
-  return responseJson.reduce((sources, source) => {
-
-    let highDef = document.createElement('source');
-    highDef.media = `(min-width: ${source.minWidth}px) and
-    (-webkit-min-device-pixel-ratio: 1.25),
-    (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`;
-    highDef.sizes = source.sizes;
-    highDef.srcset = `${window.location.protocol}${source.highDefSrcset}`;
-
-    let lowDef = document.createElement('source');
-    lowDef.media = `(min-width: ${source.minWidth}px)`;
-    lowDef.sizes = source.sizes;
-    lowDef.srcset = `${window.location.protocol}${source.lowDefSrcset}`;
-
-    sources.appendChild(highDef);
-    sources.appendChild(lowDef);
-    return sources;
-  },
-    srcsetFragment);
-}
-
-function insertBetweenComments(sources) {
-
-	let pictures = Array.from(document.querySelector('picture'));
-
-  return write(() => {
-		pictures.forEach((picture, index) => picture.insertBefore(sources[index], picture.firstChild));
-	});
 }

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -13,11 +13,11 @@ if (customUrl !== '') {
   params.append('t', customUrl);
 } else {
   params.append('k', keywords);
-};
+}
 
 enableToggles();
 getIframeId()
-.then( => fetch(`${config.capiSingleUrl}?${params}`))
+.then(() => fetch(`${config.capiSingleUrl}?${params}`))
 .then(response => response.json())
 .then(capiData => populateCard(capiData))
 .then(html => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]))
@@ -29,8 +29,8 @@ function getValue(value, fallback) { return value || fallback; }
 function populateCard(responseJson) {
     let icon = checkIcon(responseJson)
 
-    return( `<div class="adverts__row adverts__row--single">
-      <a class="blink advert advert--large advert--capi advert--media advert--inverse advert--paidfor" href="%%CLICK_URL_UNESC%%${getValue('[%ArticleUrl%]', responseJson.articleUrl)} data-link-name="merchandising | capi | single">
+    return `<div class="adverts__row adverts__row--single">
+      <a class="blink advert advert--large advert--capi advert--media advert--inverse advert--paidfor" href="%%CLICK_URL_UNESC%%${getValue('[%ArticleUrl%]', responseJson.articleUrl)}" data-link-name="merchandising | capi | single">
       <div class="advert__text">
         <h2 class="blink__anchor advert__title">
           ${icon}
@@ -54,8 +54,8 @@ function populateCard(responseJson) {
       <a class="adverts__badge__link" href="" data-link-name="logo link">
         <img class="adverts__badge__logo" src="${getValue('[%BrandLogo%]', responseJson.branding.sponsorLogo.url)}" alt="">
       </a>
-    </div>`)
-};
+    </div>`;
+}
 
 function checkIcon(responseJson) {
     return responseJson.audioTag ?
@@ -65,4 +65,33 @@ function checkIcon(responseJson) {
     responseJson.videoTag ?
         videoIcon :
         '';
-};
+}
+
+function createSourceset(responseJson) {
+
+  let srcsetFragment = document.createDocumentFragment();
+
+  return responseJson.reduce((sources, source) => {
+
+    let highDef = document.createElement('source');
+    highDef.media = `(min-width: ${source.minWidth}px) and
+    (-webkit-min-device-pixel-ratio: 1.25),
+    (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`;
+    highDef.sizes = source.sizes;
+    highDef.srcset = `${window.location.protocol}${source.highDefSrcset}`;
+
+    let lowDef = document.createElement('source');
+    lowDef.media = `(min-width: ${source.minWidth}px)`;
+    lowDef.sizes = source.sizes;
+    lowDef.srcset = `${window.location.protocol}${source.lowDefSrcset}`;
+
+    sources.appendChild(highDef);
+    sources.appendChild(lowDef);
+
+  }, srcsetFragment);
+}
+
+
+function addImages(){
+  
+}

--- a/src/capi-single-paid/test.json
+++ b/src/capi-single-paid/test.json
@@ -5,5 +5,6 @@
 	"ArticleHeadline": "",
 	"ArticleUrl": "",
 	"ArticleText": "",
-	"ArticleImage": ""
+	"ArticleImage": "",
+	"BrandLogo": ""
 }

--- a/src/capi-single-supported/index.html
+++ b/src/capi-single-supported/index.html
@@ -1,0 +1,9 @@
+<aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--supported adverts--tone-supported">
+</aside>
+
+<script>
+var arrowRight = '{{#svg}}arrow-right{{/svg}}';
+var audioIcon = '{{#svg}}audio{{/svg}}';
+var imageIcon = '{{#svg}}image{{/svg}}';
+var videoIcon = '{{#svg}}video{{/svg}}';
+</script>

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -1,8 +1,6 @@
-import config from '../_shared/js/config';
 import { enableToggles } from '../_shared/js/ui.js';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
-import { portify } from '../_shared/js/dev';
 import { addSourceset, insertBetweenComments, checkIcon } from '../_shared/js/images.js';
 
 let container = document.getElementsByClassName('adverts--supported')[0];

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -18,7 +18,7 @@ if (customUrl !== '') {
 
 enableToggles();
 getIframeId()
-.then(() => fetch(`${config.capiSingleUrl}?${params}`))
+.then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
 .then(capiData => [addSourceset(capiData.articleImage.sources), populateCard(capiData)])
 .then(([sources, html]) => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]).then(() => insertBetweenComments(sources)))

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -3,6 +3,7 @@ import { enableToggles } from '../_shared/js/ui.js';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
 import { portify } from '../_shared/js/dev';
+import { addSourceset, insertBetweenComments, checkIcon } from '../_shared/js/images.js';
 
 let container = document.getElementsByClassName('adverts--supported')[0];
 let params = new URLSearchParams();
@@ -69,48 +70,4 @@ function populateCard(responseJson) {
       </a>
     </div>
     </div>`;
-}
-
-function checkIcon(responseJson) {
-    return responseJson.audioTag ?
-        audioIcon :
-    responseJson.galleryTag ?
-        imageIcon :
-    responseJson.videoTag ?
-        videoIcon :
-        '';
-}
-
-function addSourceset(responseJson) {
-
-  let srcsetFragment = document.createDocumentFragment();
-
-  return responseJson.reduce((sources, source) => {
-
-    let highDef = document.createElement('source');
-    highDef.media = `(min-width: ${source.minWidth}px) and
-    (-webkit-min-device-pixel-ratio: 1.25),
-    (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`;
-    highDef.sizes = source.sizes;
-    highDef.srcset = `${window.location.protocol}${source.highDefSrcset}`;
-
-    let lowDef = document.createElement('source');
-    lowDef.media = `(min-width: ${source.minWidth}px)`;
-    lowDef.sizes = source.sizes;
-    lowDef.srcset = `${window.location.protocol}${source.lowDefSrcset}`;
-
-    sources.appendChild(highDef);
-    sources.appendChild(lowDef);
-    return sources;
-  },
-    srcsetFragment);
-}
-
-function insertBetweenComments(sources) {
-
-	let pictures = Array.from(document.querySelector('picture'));
-
-  return write(() => {
-		pictures.forEach((picture, index) => picture.insertBefore(sources[index], picture.firstChild));
-	});
 }

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -1,0 +1,80 @@
+import config from '../_shared/js/config';
+import { enableToggles } from '../_shared/js/ui.js';
+import { write } from '../_shared/js/dom';
+import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
+import { portify } from '../_shared/js/dev';
+
+let container = document.getElementsByClassName('adverts--supported')[0];
+let params = new URLSearchParams();
+let keywords = '[%SeriesUrl%]';
+let customUrl = '[%CustomUrl%]';
+
+if (customUrl !== '') {
+  params.append('t', customUrl);
+} else {
+  params.append('k', keywords);
+};
+
+enableToggles();
+getIframeId()
+.then(() => fetch(`${config.capiSingleUrl}?${params}`))
+.then(response => response.json())
+.then(capiData => populateCard(capiData))
+.then(html => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]))
+.then(resizeIframeHeight);
+
+function getValue(value, fallback) { return value || fallback; }
+
+/* Outputs the HTML for a travel advert */
+function populateCard(responseJson) {
+    let icon = checkIcon(responseJson)
+
+    return`<header class="adverts__header">
+      <h1 class="adverts__title">
+        <a class="adverts__logo blink" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesUrl%]" data-link-name="header link">
+          [%ComponentTitle%]
+        </a>
+      </h1>
+      <div class="adverts__badge adverts__badge--alt js-badge">
+        Supported by
+        <a class="adverts__badge__link" href="[%SeriesUrl%]%%" data-link-name="logo link">
+        <img class="adverts__badge__logo" src="${getValue('[%BrandLogo%]', responseJson.branding.sponsorLogo.url)}" alt="">
+      </a>
+      <a href="%%CLICK_URL_ESC%%http://theguardian.com/about" class="adverts__badge__help" data-link-name="about link">
+        About this content
+      </a>
+      </div>
+    </header>
+    <div class="adverts__body">
+    <div class="adverts__row adverts__row--single">
+      <a class="blink advert advert--large advert--capi advert--media advert--inverse advert--supported" href="%%CLICK_URL_UNESC%%${getValue('[%ArticleUrl%]', responseJson.articleUrl)}" data-link-name="merchandising | capi | single | [%OmnitureId%]">
+        <div class="advert__text">
+          <h2 class="blink__anchor advert__title">
+            ${icon}
+            ${getValue('[%ArticleHeadline%]', responseJson.articleHeadline)}
+          </h2>
+          <p class="advert_standfirst">
+            ${getValue('[%ArticleText%]', responseJson.articleText)}
+          </p>
+        </div>
+        <div class="advert__image-container">
+          <img class="advert__image" src="${getValue('[%ArticleImage%]', responseJson.articleImage[0].item.images.allImages[0].url)}" alt>
+        </div>
+      </a>
+      <a class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" href="%%CLICK_URL_ESC%%[%SeriesURL%]"  data-link-name="merchandising-single-more">
+        See more
+        ${arrowRight}
+      </a>
+    </div>
+    </div>`;
+}
+
+function checkIcon(responseJson) {
+    return responseJson.audioTag ?
+        audioIcon :
+    responseJson.galleryTag ?
+        imageIcon :
+    responseJson.videoTag ?
+        videoIcon :
+        '';
+}

--- a/src/capi-single-supported/index.scss
+++ b/src/capi-single-supported/index.scss
@@ -1,0 +1,6 @@
+@import '_core';
+@import '_adverts';
+@import '_advert';
+@import '_adverts-capi';
+// @import '_paidfor-meta';
+// @import '_popup-paidfor';

--- a/src/capi-single-supported/index.scss
+++ b/src/capi-single-supported/index.scss
@@ -2,5 +2,3 @@
 @import '_adverts';
 @import '_advert';
 @import '_adverts-capi';
-// @import '_paidfor-meta';
-// @import '_popup-paidfor';

--- a/src/capi-single-supported/test.json
+++ b/src/capi-single-supported/test.json
@@ -1,9 +1,10 @@
 {
 	"SeriesUrl": "spotify-discover-weekly/spotify-discover-weekly",
-	"ComponentTitle": "Spotify Discover Weekly",
+	"ComponentTitle": "Led Zeppelin Special",
 	"CustomUrl": "",
 	"ArticleHeadline": "",
 	"ArticleUrl": "",
 	"ArticleText": "",
-	"ArticleImage": ""
+	"ArticleImage": "",
+	"BrandLogo": ""
 }


### PR DESCRIPTION
This extends the work done in https://github.com/guardian/commercial-templates/pull/43. Given the different styling it was simpler to separate supported and paid-for into separate DFP templates.

This PR also fixes issues with the CAPI paid-for single such as typos (! 😱 ) and the added complexity with sourceset. 

cc @regiskuckaertz @JonNorman @Ap0c 