### PR TITLE
Fabric native

### DIFF
--- a/src/_shared/scss/_core.scss
+++ b/src/_shared/scss/_core.scss
@@ -42,6 +42,10 @@ $mq-breakpoints: (
     opacity: 1;
 }
 
+.u-root {
+    position: relative;
+}
+
 .u-button-reset {
     -webkit-appearance: none;
     background: none;
@@ -117,7 +121,6 @@ $mq-breakpoints: (
 
 .creative {
     display: block;
-    position: relative;
 }
 
 .creative__pixel {

--- a/src/_shared/scss/_core.scss
+++ b/src/_shared/scss/_core.scss
@@ -30,8 +30,8 @@ $mq-breakpoints: (
 @import '_mq';
 @import '_palette';
 @import '_defaults';
-@import '_helpers';
 @import '_ui';
+@import '_helpers';
 
 .wf-loading {
     opacity: 0;

--- a/src/_shared/scss/_helpers.scss
+++ b/src/_shared/scss/_helpers.scss
@@ -12,21 +12,20 @@
 
 .gs-container {
     position: relative;
-    margin: 0 auto;
 
     @include mq(tablet) {
-        max-width: gs-span(9) + $gs-gutter * 2;
+        padding: 0 calc(50% - #{(gs-span(9) + $gs-gutter * 2) / 2});
     }
 
     @include mq(desktop) {
-        max-width: gs-span(12) + $gs-gutter * 2;
+        padding: 0 calc(50% - #{(gs-span(12) + $gs-gutter * 2) / 2});
     }
 
     @include mq(leftCol) {
-        max-width: gs-span(14) + $gs-gutter * 2;
+        padding: 0 calc(50% - #{(gs-span(14) + $gs-gutter * 2) / 2});
     }
 
     @include mq(wide) {
-        max-width: gs-span($gs-max-columns) + $gs-gutter * 2;
+        padding: 0 calc(50% - #{(gs-span($gs-max-columns) + $gs-gutter * 2) / 2});
     }
 }

--- a/src/_shared/scss/_helpers.scss
+++ b/src/_shared/scss/_helpers.scss
@@ -9,3 +9,24 @@
         display: none !important;
     }
 }
+
+.gs-container {
+    position: relative;
+    margin: 0 auto;
+
+    @include mq(tablet) {
+        max-width: gs-span(9) + $gs-gutter * 2;
+    }
+
+    @include mq(desktop) {
+        max-width: gs-span(12) + $gs-gutter * 2;
+    }
+
+    @include mq(leftCol) {
+        max-width: gs-span(14) + $gs-gutter * 2;
+    }
+
+    @include mq(wide) {
+        max-width: gs-span($gs-max-columns) + $gs-gutter * 2;
+    }
+}

--- a/src/fabric/index.html
+++ b/src/fabric/index.html
@@ -1,6 +1,6 @@
 <div class="creative creative--fabric" style="background:[%BackgroundColour%]">
     <a class="creative__link" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-        <div class="creative__alt creative__alt--tablet hide-until-tablet background-effect--[%ScrollType%]"
+        <div class="gs-container creative__alt creative__alt--tablet hide-until-tablet background-effect--[%ScrollType%]"
             style="background-image: url('[%BackgroundImage%]');
             background-position: [%BackgroundImagePosition%];
             background-repeat: [%BackgroundImageRepeat%];"
@@ -18,7 +18,7 @@
                 background-position: [%Layer3BackgroundPosition%]"
                 ></div>
         </div>
-        <div class="creative__alt creative__alt--mobile mobile-only background-effect--[%ScrollType%]"
+        <div class="gs-container creative__alt creative__alt--mobile mobile-only background-effect--[%ScrollType%]"
             style="background-image: url('[%MobileBackgroundImage%]');
             background-position: [%MobileBackgroundImagePosition%];
             background-repeat: [%MobileBackgroundImageRepeat%];"

--- a/src/fabric/index.html
+++ b/src/fabric/index.html
@@ -1,6 +1,6 @@
-<div class="creative creative--fabric" style="background:[%BackgroundColour%]">
-    <a class="creative__link" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-        <div class="gs-container creative__alt creative__alt--tablet hide-until-tablet background-effect--[%ScrollType%]"
+<div class="gs-container creative creative--fabric" style="background:[%BackgroundColour%]">
+    <a class="blink u-root creative__link" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+        <div class="creative__alt creative__alt--tablet hide-until-tablet background-effect--[%ScrollType%]"
             style="background-image: url('[%BackgroundImage%]');
             background-position: [%BackgroundImagePosition%];
             background-repeat: [%BackgroundImageRepeat%];"
@@ -18,7 +18,7 @@
                 background-position: [%Layer3BackgroundPosition%]"
                 ></div>
         </div>
-        <div class="gs-container creative__alt creative__alt--mobile mobile-only background-effect--[%ScrollType%]"
+        <div class="creative__alt creative__alt--mobile mobile-only background-effect--[%ScrollType%]"
             style="background-image: url('[%MobileBackgroundImage%]');
             background-position: [%MobileBackgroundImagePosition%];
             background-repeat: [%MobileBackgroundImageRepeat%];"

--- a/src/fabric/index.scss
+++ b/src/fabric/index.scss
@@ -1,7 +1,11 @@
 @import '_core';
 
 .creative--fabric {
-    height: 250px;
+
+    &,
+    & > .creative__link {
+        height: 250px;
+    }
 
     .creative__layer1 { z-index: 1; }
     .creative__layer2 { z-index: 2; }


### PR DESCRIPTION
This works:

![picture 3](https://cloud.githubusercontent.com/assets/629976/19013207/d91fec34-87c1-11e6-8e3c-9848ca7a2bc6.jpg)

Introducing two important utility classes:

- `gs-container` will create a 100% container which has a content area matching the content area of the website and left-/right-padding that will fill the remaining space

- `u-root` sets the element as a containing block, i.e. it applies `position: relative`
