### PR TITLE
Improve resizeIframeHeight

### DIFF
--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -97,7 +97,7 @@ function isDocumentLoaded() {
 function areImagesLoaded() {
     return Array.from(
         document.getElementsByTagName('img'),
-        function (img) { return img.complete ? Promise.resolve() : new Promise(resolve => img.onload = resolve); }
+        img => img.complete ? Promise.resolve() : new Promise(resolve => img.onload = resolve)
     );
 }
 

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -81,11 +81,8 @@ export function getWebfonts(fontFamilies) {
 }
 
 export function resizeIframeHeight() {
-    return Promise.all([
-        isDocumentLoaded(),
-        ...areImagesLoaded()
-    ])
-    .then(() => read(() => window.innerHeight))
+    return Promise.all([isDocumentLoaded()].concat(areImagesLoaded()))
+    .then(() => read(() => document.body.getBoundingClientRect().height))
     .then(function(height) {
         return sendMessage('resize', { height });
     });
@@ -100,7 +97,7 @@ function isDocumentLoaded() {
 function areImagesLoaded() {
     return Array.from(
         document.getElementsByTagName('img'),
-        img => img.complete ? Promise.resolve() : new Promise(resolve => img.onload = resolve)
+        function (img) { return img.complete ? Promise.resolve() : new Promise(resolve => img.onload = resolve); }
     );
 }
 


### PR DESCRIPTION
`window.innerHeight` is the height of the _viewport_, which may not necessarily be equal to the height of the _creative_, since it relies on the geometry of the parent iframe element. Instead we'll resort to computing the geometry of the `BODY`, which is a good proxy for our needs.

Not happy with how rollup deals with the `...` spread operator inside arrays, so I switched to a more conventional `concat` op.

(Of course, after merging, all creatives must be re-generated and manually uploaded in DFP. We need a command line to do that 😭 )