### PR TITLE
Incorporate 3 variants of Glabs landing page in Capi Single Paid

### DIFF
--- a/src/capi-single-paid/index.html
+++ b/src/capi-single-paid/index.html
@@ -18,7 +18,7 @@
       </a>
     </h1>
     <div class="adverts__stamp">
-      <a href="/guardian-labs" class="creative__glabs-link js-glabs-link" data-link-name="labs logo">
+      <a href="" class="creative__glabs-link js-glabs-link" data-link-name="labs logo">
         {{#svg}}glabs-logo{{/svg}}
       </a>
     </div>

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -9,6 +9,12 @@ let params = new URLSearchParams();
 let keywords = '[%SeriesUrl%]';
 let customUrl = '[%CustomUrl%]';
 
+const GLABS_EDITION = {
+  default: 'https://theguardian.com/guardian-labs',
+	au: 'https://theguardian.com/guardian-labs-australia',
+	us: 'https://theguardian.com/guardian-labs-us'
+ };
+
 if (customUrl !== '') {
   params.append('t', customUrl);
 } else {
@@ -25,9 +31,21 @@ getIframeId()
 
 function getValue(value, fallback) { return value || fallback; }
 
+function glabsLink(responseJson) {
+  let logo = document.getElementsByClassName('creative__glabs-link')[0];
+
+  responseJson.edition === "AU" ?
+      logo.href = GLABS_EDITION.au:
+  responseJson.edition === "US" ?
+      logo.href = GLABS_EDITION.us:
+      logo.href = GLABS_EDITION.default;
+}
+
 /* Outputs the HTML for a travel advert */
 function populateCard(responseJson) {
     let icon = checkIcon(responseJson)
+    glabsLink(responseJson);
+
 
     return `<div class="adverts__row adverts__row--single">
       <a class="blink advert advert--large advert--capi advert--media advert--inverse advert--paidfor" href="%%CLICK_URL_UNESC%%${getValue('[%ArticleUrl%]', responseJson.articleUrl)}" data-link-name="merchandising | capi | single | [%TrackingId%]">


### PR DESCRIPTION
Small fix to reflect the 3 variants of the glabs landing page. This is only relevant for CAPI single paid. Following earlier work on the front-end controller, the JS checks edition data and decides relevant logo link.

cc @regiskuckaertz 