### PR TITLE
Small CSS tweaks to CAPI Single templates

### DIFF
--- a/src/capi-single-paid/index.html
+++ b/src/capi-single-paid/index.html
@@ -4,7 +4,7 @@
       <div class="paidfor-meta">
         <span class="paidfor-meta__label">Paid content</span>
         <div class="paidfor-meta__more has-popup">
-            <button class="u-button-reset js-toggle" aria-controls="popup" aria-expanded="true">About {{#svg}}arrow-down{{/svg}}</button>
+            <button class="u-button-reset js-toggle paidfor-meta__label" aria-controls="popup" aria-expanded="true">About {{#svg}}arrow-down{{/svg}}</button>
             <div id="popup" class="popup popup--paidfor">
                 <p>Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</p>
                 <a href="/content-funding">Learn more about Guardian Labs content {{#svg}}arrow-right{{/svg}}</a>

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -1,7 +1,6 @@
 import { enableToggles } from '../_shared/js/ui';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
-import { getApiBaseUrl } from '../_shared/js/dev';
 import { addSourceset, buildImages, checkIcon } from '../_shared/js/images';
 
 let container = document.getElementsByClassName('adverts__body')[0];
@@ -26,7 +25,7 @@ getIframeId()
 .then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
 .then(capiData => [addSourceset(capiData.articleImage.sources), populateCard(capiData)])
-.then(([sources, html]) => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]).then(() => buildImages(sources)))
+.then(([sources, html]) => Promise.all([getWebfonts(), write(() => container.innerHTML = html)]).then(() => buildImages(sources)))
 .then(resizeIframeHeight);
 
 function getValue(value, fallback) { return value || fallback; }

--- a/src/capi-single-paid/index.scss
+++ b/src/capi-single-paid/index.scss
@@ -4,3 +4,7 @@
 @import '_adverts-capi';
 @import '_paidfor-meta';
 @import '_popup-paidfor';
+
+.paidfor-meta__more .paidfor-meta__label {
+    font-weight: normal;
+}

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -19,7 +19,7 @@ getIframeId()
 .then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
 .then(capiData => [addSourceset(capiData.articleImage.sources), populateCard(capiData)])
-.then(([sources, html]) => Promise.all(write(() => container.innerHTML = html)).then(() => buildImages(sources)).then(getWebfonts()))
+.then(([sources, html]) => Promise.all([getWebfonts(), write(() => container.innerHTML = html)]).then(() => buildImages(sources)))
 .then(resizeIframeHeight);
 
 function getValue(value, fallback) { return value || fallback; }

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -19,7 +19,7 @@ getIframeId()
 .then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
 .then(capiData => [addSourceset(capiData.articleImage.sources), populateCard(capiData)])
-.then(([sources, html]) => Promise.all([getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']), write(() => container.innerHTML = html)]).then(() => buildImages(sources)))
+.then(([sources, html]) => Promise.all(write(() => container.innerHTML = html)).then(() => buildImages(sources)).then(getWebfonts()))
 .then(resizeIframeHeight);
 
 function getValue(value, fallback) { return value || fallback; }

--- a/src/capi-single-supported/index.scss
+++ b/src/capi-single-supported/index.scss
@@ -1,4 +1,10 @@
 @import '_core';
 @import '_adverts';
-@import '_advert';
 @import '_adverts-capi';
+@import '_advert';
+@import '_brandbadge';
+
+.button--primary {
+  background-color: #005689;
+  color: #fff;
+}


### PR DESCRIPTION
- WebFonts were being retrieved but not rendered on CAPI supported. This was because the page had to wait for the HTML to be rendered
- The button on Supported was not the correct style - added background and border color
- The popup tag on CAPI paid was incorrect, adding correct tag and specific styling fixed this.

cc @regiskuckaertz 