### PR TITLE
Fix Capi Prod Errors

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -131,8 +131,7 @@ function buildCard (cardInfo, cardNum, isPaid) {
 // Adds branding information from cAPI or DFP override.
 function addBranding (brandingCard, isPaid) {
 
-	let imageClass = `.${isPaid ? 'adverts__' : ''}badge__logo`;
-	let brandImage = document.querySelector(imageClass);
+	let brandImage = document.querySelector('.badge__logo');
 
 	if (OVERRIDES.brandLogo === '') {
 		brandImage.src = brandingCard.branding.sponsorLogo.url;

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -129,7 +129,7 @@ function buildCard (cardInfo, cardNum, isPaid) {
 }
 
 // Adds branding information from cAPI or DFP override.
-function addBranding (brandingCard, isPaid) {
+function addBranding (brandingCard) {
 
 	let brandImage = document.querySelector('.badge__logo');
 
@@ -172,7 +172,7 @@ function buildFromCapi (cardsInfo, isPaid) {
 	return () => {
 
 		// Takes branding from last possible card, in case earlier ones overriden.
-		addBranding(cardsInfo.articles.slice(-1)[0], isPaid);
+		addBranding(cardsInfo.articles.slice(-1)[0]);
 		let advertRow = document.querySelector('.adverts__row');
 		advertRow.appendChild(cardList);
 		editionLink(cardsInfo.articles[0].edition, isPaid);

--- a/src/capi-multiple-paidfor/index.scss
+++ b/src/capi-multiple-paidfor/index.scss
@@ -4,9 +4,10 @@
 @import '_advert';
 @import '_popup-paidfor';
 @import '_paidfor-meta';
+@import '_palette';
 
 .adverts {
-	color: #333;
+	color: $neutral-1;
 }
 
 // SVG dimensions.

--- a/src/capi-multiple-paidfor/index.scss
+++ b/src/capi-multiple-paidfor/index.scss
@@ -5,6 +5,10 @@
 @import '_popup-paidfor';
 @import '_paidfor-meta';
 
+.adverts {
+	color: #333;
+}
+
 // SVG dimensions.
 .icon--arrow-down > svg {
 	width: 24px;

--- a/src/capi-multiple-supported/index.scss
+++ b/src/capi-multiple-supported/index.scss
@@ -3,9 +3,10 @@
 @import '_adverts-capi';
 @import '_advert';
 @import '_brandbadge';
+@import '_palette';
 
 .adverts {
-	color: #333;
+	color: $neutral-1;
 }
 
 // For cards 3 and 4.

--- a/src/capi-multiple-supported/index.scss
+++ b/src/capi-multiple-supported/index.scss
@@ -4,6 +4,10 @@
 @import '_advert';
 @import '_brandbadge';
 
+.adverts {
+	color: #333;
+}
+
 // For cards 3 and 4.
 .hide-until-mobile-landscape {
     @include mq($until: mobileLandscape) {


### PR DESCRIPTION
# In This PR

Minor fixes noticed in PROD testing:

- JS selector was using a class that got renamed, fixed this (didn't show up locally for some reason).
- Updated text colouring to match pre-existing capi ads (think this was previously inheriting from `body`, no longer possible in iframe)

@regiskuckaertz @annebyrne @JonNorman @Calum-Campbell 