### PR TITLE
Fix for Chrome bug on CAPI Supported Single Template

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -10,10 +10,11 @@ function buildJs(src, minify) {
             format: 'iife',
             exports: 'none',
             sourceMap: false,
-            intro: 'document.addEventListener("DOMContentLoaded", function(){',
-            outro: '})'
+            intro: 'if(document.readyState !== "loading") { boot(); } else { document.addEventListener("DOMContentLoaded", boot); }; function boot(){',
+            outro: '}'
         }).code;
         return minify ? uglify.minify(code, { fromString: true }).code : code;
+        return code;
     });
 }
 

--- a/src/_shared/js/dom.js
+++ b/src/_shared/js/dom.js
@@ -9,7 +9,7 @@ const closest = 'closest' in Element.prototype ?
         return node;
     };
 
-if( ! window.requestAnimationFrame ) {
+if( ! 'requestAnimationFrame' in window ) {
     window.requestAnimationFrame = window.webkitRequestAnimationFrame || (callback => setTimeout(callback, 1000 / 60));
 }
 
@@ -22,7 +22,8 @@ function write(fn, ...args) {
 function read(fn, ...args) {
     return new Promise(resolve => window.requestAnimationFrame(() => {
         resolve(fn(...args));
-    }));
+      })
+    );
 }
 
 function createElement(tagName) {

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -1,4 +1,4 @@
-import { read, write } from './dom.js';
+import { read, write } from './dom';
 import { timeout } from './impl/promises';
 
 const rootElement = document.documentElement;
@@ -81,7 +81,7 @@ function getWebfonts(fontFamilies) {
 }
 
 function resizeIframeHeight() {
-    return Promise.all([isDocumentLoaded()].concat(areImagesLoaded()))
+    return Promise.all(areImagesLoaded().concat(isDocumentLoaded()))
     .then(() => read(() => document.body.getBoundingClientRect().height))
     .then(function(height) {
         return sendMessage('resize', { height });
@@ -122,7 +122,7 @@ function sendMessage(type, value) {
                 reject(error);
             }
         });
-
+        console.log("sending message", id, iframeId, type, value);
         post(id, iframeId, type, value);
     }), 300);
 }

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -122,7 +122,6 @@ function sendMessage(type, value) {
                 reject(error);
             }
         });
-        console.log("sending message", id, iframeId, type, value);
         post(id, iframeId, type, value);
     }), 300);
 }

--- a/src/capi-single-supported/index.html
+++ b/src/capi-single-supported/index.html
@@ -1,4 +1,21 @@
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--supported adverts--tone-supported">
+  <header class="adverts__header">
+    <h1 class="adverts__title">
+      <a class="adverts__logo blink" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesUrl%]" data-link-name="header link">
+        [%ComponentTitle%]
+      </a>
+    </h1>
+    <div class="badge badge--alt js-badge">
+      Supported by
+      <a class="badge__link" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesUrl%]" data-link-name="logo link">
+      </a>
+      <a href="/content-funding" class="badge__help" data-link-name="about link">
+          About this content
+      </a>
+    </div>
+  </header>
+  <div class="adverts__body">
+  </div>
 </aside>
 
 <script>

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -17,7 +17,7 @@ if (customUrl !== '') {
 getIframeId()
 .then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
-.then(capiData => [populateLogo(capiData), populateCard(capiData)])
+.then(capiData => [populateLogo(capiData), populateCard(capiData), capiData.articleImage])
 .then(([logo, body, imageInfo]) => Promise.all([getWebfonts(), write(() => header.innerHTML = logo, container.innerHTML = body).then(() => addImage(imageInfo))]))
 .then(resizeIframeHeight);
 

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -1,9 +1,9 @@
-import { enableToggles } from '../_shared/js/ui';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
-import { insertImage, checkIcon } from '../_shared/js/capi-images.js';
+import { insertImage, checkIcon } from '../_shared/js/capi-images';
 
-let container = document.getElementsByClassName('adverts--supported')[0];
+let container = document.getElementsByClassName('adverts__body')[0];
+let header = document.getElementsByClassName('badge__link')[0];
 let params = new URLSearchParams();
 let keywords = '[%SeriesUrl%]';
 let customUrl = '[%CustomUrl%]';
@@ -14,12 +14,11 @@ if (customUrl !== '') {
   params.append('k', keywords);
 };
 
-enableToggles();
 getIframeId()
 .then(() => fetch(`https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?${params}`))
 .then(response => response.json())
-.then(capiData => [capiData.articleImage, populateCard(capiData)])
-.then(([imageInfo, html]) => Promise.all([getWebfonts(), write(() => container.innerHTML = html)]).then(() => addImage(imageInfo)))
+.then(capiData => [populateLogo(capiData), populateCard(capiData)])
+.then(([logo, body, imageInfo]) => Promise.all([getWebfonts(), write(() => header.innerHTML = logo, container.innerHTML = body).then(() => addImage(imageInfo))]))
 .then(resizeIframeHeight);
 
 function getValue(value, fallback) { return value || fallback; }
@@ -36,28 +35,16 @@ function addImage (imageInfo) {
 
 }
 
+function populateLogo(responseJson) {
+  return `<img class="badge__logo" src="${getValue('[%BrandLogo%]', responseJson.branding.sponsorLogo.url)}" alt="">`;
+}
+
+
 /* Outputs the HTML */
 function populateCard(responseJson) {
     let icon = checkIcon(responseJson)
 
-    return`<header class="adverts__header">
-      <h1 class="adverts__title">
-        <a class="adverts__logo blink" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesUrl%]" data-link-name="header link">
-          [%ComponentTitle%]
-        </a>
-      </h1>
-      <div class="badge badge--alt js-badge">
-        Supported by
-        <a class="badge__link" href="[%SeriesUrl%]%%" data-link-name="logo link">
-        <img class="badge__logo" src="${getValue('[%BrandLogo%]', responseJson.branding.sponsorLogo.url)}" alt="">
-      </a>
-      <a href="%%CLICK_URL_ESC%%http://theguardian.com/about" class="badge__help" data-link-name="about link">
-        About this content
-      </a>
-      </div>
-    </header>
-    <div class="adverts__body">
-    <div class="adverts__row adverts__row--single">
+    return `<div class="adverts__row adverts__row--single">
       <a class="blink advert advert--large advert--capi advert--media advert--inverse advert--supported" href="%%CLICK_URL_UNESC%%${getValue('[%ArticleUrl%]', responseJson.articleUrl)}" data-link-name="merchandising | capi | single | [%TrackingId%]">
         <div class="advert__text">
           <h2 class="blink__anchor advert__title">
@@ -69,11 +56,9 @@ function populateCard(responseJson) {
           </p>
         </div>
         <div class="advert__image-container"></div>
-      </a>
-      <a class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" href="%%CLICK_URL_ESC%%[%SeriesUrl%]"  data-link-name="merchandising-single-more">
+      <a class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesUrl%]"  data-link-name="merchandising-single-more">
         See more
         ${arrowRight}
       </a>
-    </div>
     </div>`;
 }


### PR DESCRIPTION
**Bug**
Chrome has a bug whereby requestAnimationFrame does not work with empty elements. 

Previously the CAPI Single Supported template had a single aside tag in its HTML, and the template was rendered by the javascript for simplicity due to header and body structure.This meant that the element had no height associated with it. 

**FIx**
The population of CAPI data in the header and the body of the component has been separated into 2 different functions and the HTML includes more content prior to JS rendering.

There have been a few small changes to shared JS files.

**Screenshots**

Firefox:

<img width="1169" alt="screen shot 2016-10-06 at 18 40 37" src="https://cloud.githubusercontent.com/assets/14946184/19163575/719a37f4-8bf4-11e6-8cee-80aa1784f143.png">

Chrome:

![screen shot 2016-10-06 at 18 41 31](https://cloud.githubusercontent.com/assets/14946184/19163599/88a76c32-8bf4-11e6-8a5b-13eb05c40b22.png)

cc @guardian/commercial-dev @regiskuckaertz 
