### PR TITLE
Open links in a new tab

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ const args = require('yargs').argv;
 
 // options
 const options = {
-    banner: '<base target="_top" href="https://www.theguardian.com">',
+    banner: '<base target="_blank" href="https://www.theguardian.com">',
     src: 'src',
     dst: 'build',
     minify: args.minify


### PR DESCRIPTION
This is the standard behaviour for all our ads, plus it will allow us to track clicks more consistently.