### PR TITLE
Traffic Driver cAPI Integration

### DIFF
--- a/src/_shared/js/ads.js
+++ b/src/_shared/js/ads.js
@@ -4,9 +4,9 @@ const trackingPixel = '[%Trackingpixel%]';
 
 // Glabs edition links.
 const GLABS_EDITION = {
-	default: 'https://theguardian.com/guardian-labs',
-	au: 'https://theguardian.com/guardian-labs-australia',
-	us: 'https://theguardian.com/guardian-labs-us'
+	DEFAULT: '/guardian-labs',
+	AU: '/guardian-labs-australia',
+	US: '/guardian-labs-us'
 };
 
 let pixelTemplate;
@@ -26,15 +26,5 @@ export function addTrackingPixel(rootNode) {
 
 // Sets the 'href' of the glabs edition link to the correct URL.
 export function setEditionLink (edition, linkElement) {
-
-	let link = GLABS_EDITION.default;
-
-	if (edition === 'AU') {
-		link = GLABS_EDITION.au;
-	} else if (edition === 'US') {
-		link = GLABS_EDITION.us;
-	}
-
-	linkElement.href = link;
-
+	linkElement.href = GLABS_EDITION[edition] || GLABS_EDITION.DEFAULT;
 }

--- a/src/_shared/js/ads.js
+++ b/src/_shared/js/ads.js
@@ -1,6 +1,14 @@
 import { write } from './dom';
 
 const trackingPixel = '[%Trackingpixel%]';
+
+// Glabs edition links.
+const GLABS_EDITION = {
+	default: 'https://theguardian.com/guardian-labs',
+	au: 'https://theguardian.com/guardian-labs-australia',
+	us: 'https://theguardian.com/guardian-labs-us'
+};
+
 let pixelTemplate;
 
 export function addTrackingPixel(rootNode) {
@@ -14,4 +22,19 @@ export function addTrackingPixel(rootNode) {
     const pixel = pixelTemplate.cloneNode();
     pixel.src = '[%Trackingpixel%]%%CACHEBUSTER%%';
     return write(() => rootNode.appendChild(pixel));
+}
+
+// Sets the 'href' of the glabs edition link to the correct URL.
+export function setEditionLink (edition, linkElement) {
+
+	let link = GLABS_EDITION.default;
+
+	if (edition === 'AU') {
+		link = GLABS_EDITION.au;
+	} else if (edition === 'US') {
+		link = GLABS_EDITION.us;
+	}
+
+	linkElement.href = link;
+
 }

--- a/src/_shared/js/capi-images.js
+++ b/src/_shared/js/capi-images.js
@@ -46,10 +46,10 @@ function createPicture (imageInfo, imageElem) {
 }
 
 // Inserts an image into the card, using the data derived from cAPI.
-export function insertImage (imageContainer, imageInfo, override) {
+export function insertImage (imageContainer, imageInfo, classes, override) {
 
 	let image = document.createElement('img');
-	image.classList.add('advert__image');
+	image.classList.add(...classes);
 
 	if (override) {
 

--- a/src/_shared/js/capi-images.js
+++ b/src/_shared/js/capi-images.js
@@ -49,7 +49,7 @@ function createPicture (imageInfo, imageElem) {
 export function insertImage (imageContainer, imageInfo, classes, override) {
 
 	let image = document.createElement('img');
-	image.classList.add(...classes);
+	image.className = classes.join(' ');
 
 	if (override) {
 

--- a/src/_shared/js/capi-images.js
+++ b/src/_shared/js/capi-images.js
@@ -63,6 +63,8 @@ export function insertImage (imageContainer, imageInfo, classes, override) {
 
 	}
 
+	return image;
+
 }
 
 // Retrieves svg icons for capi single.

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -3,15 +3,9 @@ import { getIframeId, getWebfonts, resizeIframeHeight } from
 import { write } from './dom.js';
 import { enableToggles } from './ui.js';
 import { insertImage } from './capi-images.js';
+import { setEditionLink } from './ads';
 
 const ENDPOINT = 'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-multiple.json';
-
-// Glabs edition links.
-const GLABS_EDITION = {
-	default: 'https://theguardian.com/guardian-labs',
-	au: 'https://theguardian.com/guardian-labs-australia',
-	us: 'https://theguardian.com/guardian-labs-us'
-};
 
 const OVERRIDES = {
 	urls: ['[%Article1URL%]', '[%Article2URL%]', '[%Article3URL%]',
@@ -117,7 +111,8 @@ function buildCard (cardInfo, cardNum, isPaid) {
 
 	buildTitle(card, cardInfo, cardNum);
 	card.querySelector('a.advert').href = cardInfo.articleUrl;
-	insertImage(imgContainer, cardInfo.articleImage, OVERRIDES.images[cardNum]);
+	insertImage(imgContainer, cardInfo.articleImage, ['advert__image'],
+		OVERRIDES.images[cardNum]);
 
 	// Only first two cards show on mobile portrait.
 	if (cardNum >= 2) {
@@ -143,17 +138,7 @@ function addBranding (brandingCard) {
 function editionLink (edition, isPaid) {
 
 	if (isPaid) {
-
-		let link = GLABS_EDITION.default;
-
-		if (edition === 'AU') {
-			link = GLABS_EDITION.au;
-		} else if (edition === 'US') {
-			link = GLABS_EDITION.us;
-		}
-
-		document.querySelector('.adverts__stamp a').href = link;
-
+		setEditionLink(edition, document.querySelector('.adverts__stamp a'));
 	}
 
 }

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -46,7 +46,8 @@ function addImage (imageInfo) {
   return write(() => {
 
     let imageContainer = document.querySelector('.advert__image-container');
-    insertImage(imageContainer, imageInfo, '[%ArticleImage%]');
+    insertImage(imageContainer, imageInfo, ['advert__image'],
+      '[%ArticleImage%]');
 
   });
 

--- a/src/capi-single-paid/index.js
+++ b/src/capi-single-paid/index.js
@@ -2,6 +2,7 @@ import { enableToggles } from '../_shared/js/ui';
 import { write } from '../_shared/js/dom';
 import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages';
 import { insertImage, checkIcon } from '../_shared/js/capi-images.js';
+import { setEditionLink } from '../_shared/js/ads';
 
 let container = document.getElementsByClassName('adverts__body')[0];
 let params = new URLSearchParams();
@@ -56,7 +57,7 @@ function addImage (imageInfo) {
 /* Outputs the HTML for a travel advert */
 function populateCard(responseJson) {
     let icon = checkIcon(responseJson)
-    glabsLink(responseJson);
+    setEditionLink(responseJson.edition, document.querySelector('.creative__glabs-link'));
 
 
     return `<div class="adverts__row adverts__row--single">

--- a/src/capi-single-supported/index.js
+++ b/src/capi-single-supported/index.js
@@ -30,7 +30,8 @@ function addImage (imageInfo) {
   return write(() => {
 
     let imageContainer = document.querySelector('.advert__image-container');
-    insertImage(imageContainer, imageInfo, '[%ArticleImage%]');
+    insertImage(imageContainer, imageInfo, ['advert__image'],
+       '[%ArticleImage%]');
 
   });
 

--- a/src/glabs-native-traffic-driver/index.html
+++ b/src/glabs-native-traffic-driver/index.html
@@ -10,9 +10,7 @@
         </div>
     </div>
     <div class="creative__image-container">
-        <a class="creative__ctu" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" data-link-name="article image">
-            <img class="creative__image" src="[%ArticleImage%]" alt="[%ArticleImageAlternateText%]">
-        </a>
+        <a class="creative__ctu" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" data-link-name="article image"></a>
         <a href="/guardian-labs" class="creative__glabs-link js-glabs-link" data-link-name="labs logo">
             {{#svg}}glabs-logo{{/svg}}
         </a>

--- a/src/glabs-native-traffic-driver/index.html
+++ b/src/glabs-native-traffic-driver/index.html
@@ -1,4 +1,4 @@
-<div id="creative" class="creative creative--glabs-mpu" data-link-name="[%OmnitureId%]">
+<div id="creative" class="creative creative--glabs-mpu" data-link-name="[%TrackingId%]">
     <div class="creative__meta">
         <span class="creative__meta-type">Paid content</span>
         <div class="creative__meta-about has-popup">

--- a/src/glabs-native-traffic-driver/index.html
+++ b/src/glabs-native-traffic-driver/index.html
@@ -10,12 +10,12 @@
         </div>
     </div>
     <div class="creative__image-container">
-        <a class="creative__ctu" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" data-link-name="article image"></a>
+        <a class="creative__ctu" href="" data-link-name="article image"></a>
         <a href="/guardian-labs" class="creative__glabs-link js-glabs-link" data-link-name="labs logo">
             {{#svg}}glabs-logo{{/svg}}
         </a>
     </div>
-    <a class="creative__ctu" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" data-link-name="article">
+    <a class="creative__ctu" href="" data-link-name="article">
         <h2 class="creative__title">[%ArticleHeaderText%]</h2>
         <div class="creative__standfirst">[%ArticleText%]</div>
         <div class="creative__brand">

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -36,6 +36,7 @@ function buildFromCapi (data) {
 
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
 		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
+		document.querySelector('.creative__ctu') = data.articleUrl;
 
 	};
 

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -2,6 +2,25 @@ import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/mess
 import { enableToggles } from '../_shared/js/ui.js';
 import { addTrackingPixel } from '../_shared/js/ads.js';
 
+const OVERRIDES = {
+	headline: '[%ArticleHeaderText%]'
+};
+
+// Inserts a
+function insertHeadline (articleInfo) {
+
+	let headline;
+
+	if (OVERRIDES.headline !== '') {
+		headline = OVERRIDES.headline;
+	} else {
+		headline = articleInfo.articleHeadline;
+	}
+
+	document.querySelector('.creative__title').textContent = headline;
+
+}
+
 getIframeId()
 .then(() => {
     enableToggles();

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -6,7 +6,19 @@ const OVERRIDES = {
 	headline: '[%ArticleHeaderText%]'
 };
 
-// Inserts a
+// Loads the article data from CAPI in JSON format.
+function retrieveCapiData () {
+
+	let params = new URLSearchParams();
+	params.append('t', '[%ArticleShortURL%]')
+
+	let url = `${ENDPOINT}?${params}`;
+
+	return fetch(url).then(response => response.json());
+
+}
+
+// Inserts a headline into the ad, from cAPI or using override.
 function insertHeadline (articleInfo) {
 
 	let headline;
@@ -17,7 +29,9 @@ function insertHeadline (articleInfo) {
 		headline = articleInfo.articleHeadline;
 	}
 
-	document.querySelector('.creative__title').textContent = headline;
+	return () => {
+		document.querySelector('.creative__title').textContent = headline;
+	}
 
 }
 

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -4,6 +4,9 @@ import { enableToggles } from '../_shared/js/ui.js';
 import { addTrackingPixel } from '../_shared/js/ads.js';
 import { write } from '../_shared/js/dom.js';
 import { getApiBaseUrl } from '../_shared/js/dev';
+import { insertImage } from '../_shared/js/capi-images';
+
+const ENDPOINT = 'https://api.nextgen.guardianapps.co.uk/commercial/api/traffic-driver.json';
 
 // Glabs edition links.
 const GLABS_EDITION = {
@@ -14,17 +17,18 @@ const GLABS_EDITION = {
 
 const OVERRIDES = {
 	headline: '[%ArticleHeaderText%]',
-	text: '[%ArticleText%]'
+	text: '[%ArticleText%]',
+	image: '[%ArticleImage%]',
+	imageAlt: '[%ArticleImageAlternateText%]'
 };
 
 // Loads the article data from CAPI in JSON format.
 function retrieveCapiData ({host, preview}) {
 
-	let endpoint = `${getApiBaseUrl(host, preview)}/commercial/jobs/api/jobs.json?`;
 	let params = new URLSearchParams();
 	params.append('t', '[%ArticleShortURL%]')
 
-	let url = `${endpoint}?${params}`;
+	let url = `${ENDPOINT}?${params}`;
 
 	return fetch(url).then(response => response.json());
 
@@ -62,7 +66,14 @@ function buildFromCapi (data) {
 
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
 		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
-		document.querySelector('.creative__ctu').href = data.articleUrl;
+
+		let clickThrough = document.querySelector('.creative__ctu');
+		clickThrough.href = data.articleUrl;
+
+		let image = insertImage(clickThrough, data.articleImage,
+			['creative__image'], OVERRIDES.image);
+		image.alt = OVERRIDES.imageAlt;
+
 		editionLink(data.edition);
 
 	};

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -3,7 +3,8 @@ import { enableToggles } from '../_shared/js/ui.js';
 import { addTrackingPixel } from '../_shared/js/ads.js';
 
 const OVERRIDES = {
-	headline: '[%ArticleHeaderText%]'
+	headline: '[%ArticleHeaderText%]',
+	text: '[%ArticleText%]'
 };
 
 // Loads the article data from CAPI in JSON format.
@@ -18,20 +19,25 @@ function retrieveCapiData () {
 
 }
 
-// Inserts a headline into the ad, from cAPI or using override.
-function insertHeadline (articleInfo) {
+// Inserts text from capi into container element, with optional DFP override.
+function insertText (capiText, containerClass, override) {
 
-	let headline;
+	let container = document.querySelector(`.${containerClass}`);
+	let text = (override !== '') ? override : capiText;
 
-	if (OVERRIDES.headline !== '') {
-		headline = OVERRIDES.headline;
-	} else {
-		headline = articleInfo.articleHeadline;
-	}
+	container.textContent = text;
+
+}
+
+// Uses cAPI data to build the ad content.
+function buildFromCapi (data) {
 
 	return () => {
-		document.querySelector('.creative__title').textContent = headline;
-	}
+
+		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
+		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
+
+	};
 
 }
 

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -67,10 +67,13 @@ function buildFromCapi (data) {
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
 		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
 
-		let clickThrough = document.querySelector('.creative__ctu');
-		clickThrough.href = data.articleUrl;
+		let clickThroughs = document.getElementsByClassName('creative__ctu');
 
-		let image = insertImage(clickThrough, data.articleImage,
+		for (var i = clickThroughs.length - 1; i >= 0; i--) {
+			clickThroughs[i].href = data.articleUrl;
+		}
+
+		let image = insertImage(clickThroughs[0], data.articleImage,
 			['creative__image'], OVERRIDES.image);
 		image.alt = OVERRIDES.imageAlt;
 

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -1,9 +1,8 @@
 import { getIframeId, getWebfonts, resizeIframeHeight } from
-	'../_shared/js/messages.js';
-import { enableToggles } from '../_shared/js/ui.js';
-import { addTrackingPixel } from '../_shared/js/ads.js';
-import { write } from '../_shared/js/dom.js';
-import { getApiBaseUrl } from '../_shared/js/dev';
+	'../_shared/js/messages';
+import { enableToggles } from '../_shared/js/ui';
+import { addTrackingPixel } from '../_shared/js/ads';
+import { write } from '../_shared/js/dom';
 import { insertImage } from '../_shared/js/capi-images';
 
 const ENDPOINT = 'https://api.nextgen.guardianapps.co.uk/commercial/api/traffic-driver.json';

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -13,8 +13,8 @@ const GLABS_EDITION = {
 };
 
 const OVERRIDES = {
-	headline: "[%ArticleHeaderText%]",
-	text: "[%ArticleText%]"
+	headline: '[%ArticleHeaderText%]',
+	text: '[%ArticleText%]'
 };
 
 // Loads the article data from CAPI in JSON format.

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -43,9 +43,10 @@ function buildFromCapi (data) {
 
 		let clickThroughs = document.getElementsByClassName('creative__ctu');
 		let editionLink = document.querySelector('.creative__glabs-link');
+		let capiText = data.articleText.replace('<p>', '').replace('</p>', '');
 
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
-		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
+		insertText(capiText, 'creative__standfirst', OVERRIDES.text);
 		setEditionLink(data.edition, editionLink);
 
 		for (var i = clickThroughs.length - 1; i >= 0; i--) {

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -1,19 +1,30 @@
-import { getIframeId, getWebfonts, resizeIframeHeight } from '../_shared/js/messages.js';
+import { getIframeId, getWebfonts, resizeIframeHeight } from
+	'../_shared/js/messages.js';
 import { enableToggles } from '../_shared/js/ui.js';
 import { addTrackingPixel } from '../_shared/js/ads.js';
+import { write } from '../_shared/js/dom.js';
+import { getApiBaseUrl } from '../_shared/js/dev';
+
+// Glabs edition links.
+const GLABS_EDITION = {
+	default: 'https://theguardian.com/guardian-labs',
+	au: 'https://theguardian.com/guardian-labs-australia',
+	us: 'https://theguardian.com/guardian-labs-us'
+};
 
 const OVERRIDES = {
-	headline: '[%ArticleHeaderText%]',
-	text: '[%ArticleText%]'
+	headline: "[%ArticleHeaderText%]",
+	text: "[%ArticleText%]"
 };
 
 // Loads the article data from CAPI in JSON format.
-function retrieveCapiData () {
+function retrieveCapiData ({host, preview}) {
 
+	let endpoint = `${getApiBaseUrl(host, preview)}/commercial/jobs/api/jobs.json?`;
 	let params = new URLSearchParams();
 	params.append('t', '[%ArticleShortURL%]')
 
-	let url = `${ENDPOINT}?${params}`;
+	let url = `${endpoint}?${params}`;
 
 	return fetch(url).then(response => response.json());
 
@@ -29,6 +40,21 @@ function insertText (capiText, containerClass, override) {
 
 }
 
+// Sets correct glabs link based on edition (AU/All others).
+function editionLink (edition) {
+
+	let link = GLABS_EDITION.default;
+
+	if (edition === 'AU') {
+		link = GLABS_EDITION.au;
+	} else if (edition === 'US') {
+		link = GLABS_EDITION.us;
+	}
+
+	document.querySelector('.creative__glabs-link').href = link;
+
+}
+
 // Uses cAPI data to build the ad content.
 function buildFromCapi (data) {
 
@@ -36,16 +62,23 @@ function buildFromCapi (data) {
 
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
 		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
-		document.querySelector('.creative__ctu') = data.articleUrl;
+		document.querySelector('.creative__ctu').href = data.articleUrl;
+		editionLink(data.edition);
 
 	};
 
 }
 
 getIframeId()
+.then(retrieveCapiData)
+.then(buildFromCapi)
+.then(write)
 .then(() => {
     enableToggles();
     addTrackingPixel(document.getElementById('creative'));
-    return getWebfonts(['GuardianSansWeb', 'GuardianTextSansWeb'])
 })
-.then(resizeIframeHeight);
+.then(getWebfonts)
+.then(resizeIframeHeight)
+.catch(err => {
+	console.log(err);
+});

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -30,7 +30,7 @@ function retrieveCapiData ({host, preview}) {
 function insertText (capiText, containerClass, override) {
 
 	let container = document.querySelector(`.${containerClass}`);
-	let text = (override !== '') ? override : capiText;
+	let text = override || capiText;
 
 	container.textContent = text;
 

--- a/src/glabs-native-traffic-driver/index.js
+++ b/src/glabs-native-traffic-driver/index.js
@@ -1,18 +1,11 @@
 import { getIframeId, getWebfonts, resizeIframeHeight } from
 	'../_shared/js/messages';
 import { enableToggles } from '../_shared/js/ui';
-import { addTrackingPixel } from '../_shared/js/ads';
+import { addTrackingPixel, setEditionLink } from '../_shared/js/ads';
 import { write } from '../_shared/js/dom';
 import { insertImage } from '../_shared/js/capi-images';
 
 const ENDPOINT = 'https://api.nextgen.guardianapps.co.uk/commercial/api/traffic-driver.json';
-
-// Glabs edition links.
-const GLABS_EDITION = {
-	default: 'https://theguardian.com/guardian-labs',
-	au: 'https://theguardian.com/guardian-labs-australia',
-	us: 'https://theguardian.com/guardian-labs-us'
-};
 
 const OVERRIDES = {
 	headline: '[%ArticleHeaderText%]',
@@ -43,30 +36,17 @@ function insertText (capiText, containerClass, override) {
 
 }
 
-// Sets correct glabs link based on edition (AU/All others).
-function editionLink (edition) {
-
-	let link = GLABS_EDITION.default;
-
-	if (edition === 'AU') {
-		link = GLABS_EDITION.au;
-	} else if (edition === 'US') {
-		link = GLABS_EDITION.us;
-	}
-
-	document.querySelector('.creative__glabs-link').href = link;
-
-}
-
 // Uses cAPI data to build the ad content.
 function buildFromCapi (data) {
 
 	return () => {
 
+		let clickThroughs = document.getElementsByClassName('creative__ctu');
+		let editionLink = document.querySelector('.creative__glabs-link');
+
 		insertText(data.articleHeadline, 'creative__title', OVERRIDES.headline);
 		insertText(data.articleText, 'creative__standfirst', OVERRIDES.text);
-
-		let clickThroughs = document.getElementsByClassName('creative__ctu');
+		setEditionLink(data.edition, editionLink);
 
 		for (var i = clickThroughs.length - 1; i >= 0; i--) {
 			clickThroughs[i].href = data.articleUrl;
@@ -75,8 +55,6 @@ function buildFromCapi (data) {
 		let image = insertImage(clickThroughs[0], data.articleImage,
 			['creative__image'], OVERRIDES.image);
 		image.alt = OVERRIDES.imageAlt;
-
-		editionLink(data.edition);
 
 	};
 

--- a/src/glabs-native-traffic-driver/test.json
+++ b/src/glabs-native-traffic-driver/test.json
@@ -1,0 +1,10 @@
+{
+	"Trackingpixel": "",
+	"ArticleImage": "http://i.guimcode.co.uk.global.prod.fastly.net/img/static/sys-images/Guardian/Pix/audio/video/2014/11/14/1415974245203/Nadya-Tolokonnikova-left--015.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=814358069237630fbb08f8adac54efa6",
+	"ArticleImageAlternateText": "Some Text",
+	"ArticleHeaderText": "Pussy Riot's tour of London – video",
+	"ArticleText": "Luke Harding shows Pussy Riot's Nadya and Masha the sights on their first visit to London",
+	"Brand": "",
+	"BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+	"OmnitureId": ""
+}

--- a/src/glabs-native-traffic-driver/test.json
+++ b/src/glabs-native-traffic-driver/test.json
@@ -1,10 +1,11 @@
 {
+	"ArticleShortURL": "p/43b2q",
 	"Trackingpixel": "",
-	"ArticleImage": "http://i.guimcode.co.uk.global.prod.fastly.net/img/static/sys-images/Guardian/Pix/audio/video/2014/11/14/1415974245203/Nadya-Tolokonnikova-left--015.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=814358069237630fbb08f8adac54efa6",
+	"ArticleImage": "",
 	"ArticleImageAlternateText": "Some Text",
-	"ArticleHeaderText": "Pussy Riot’s tour of London – video",
-	"ArticleText": "Luke Harding shows Pussy Riot’s Nadya and Masha the sights on their first visit to London",
-	"Brand": "Does this do anything?",
+	"ArticleHeaderText": "",
+	"ArticleText": "",
+	"Brand": "",
 	"BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
 	"OmnitureId": ""
 }

--- a/src/glabs-native-traffic-driver/test.json
+++ b/src/glabs-native-traffic-driver/test.json
@@ -4,7 +4,7 @@
 	"ArticleImageAlternateText": "Some Text",
 	"ArticleHeaderText": "Pussy Riot's tour of London – video",
 	"ArticleText": "Luke Harding shows Pussy Riot's Nadya and Masha the sights on their first visit to London",
-	"Brand": "",
+	"Brand": "Does this do anything?",
 	"BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
 	"OmnitureId": ""
 }

--- a/src/glabs-native-traffic-driver/test.json
+++ b/src/glabs-native-traffic-driver/test.json
@@ -2,8 +2,8 @@
 	"Trackingpixel": "",
 	"ArticleImage": "http://i.guimcode.co.uk.global.prod.fastly.net/img/static/sys-images/Guardian/Pix/audio/video/2014/11/14/1415974245203/Nadya-Tolokonnikova-left--015.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=814358069237630fbb08f8adac54efa6",
 	"ArticleImageAlternateText": "Some Text",
-	"ArticleHeaderText": "Pussy Riot's tour of London – video",
-	"ArticleText": "Luke Harding shows Pussy Riot's Nadya and Masha the sights on their first visit to London",
+	"ArticleHeaderText": "Pussy Riot’s tour of London – video",
+	"ArticleText": "Luke Harding shows Pussy Riot’s Nadya and Masha the sights on their first visit to London",
 	"Brand": "Does this do anything?",
 	"BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
 	"OmnitureId": ""


### PR DESCRIPTION
# Changes

- Modifies the Glabs Native Traffic Driver to pull its content from cAPI.
- Added optional DFP overrides for content.
- Modified `capi-images` module to allow usage from multiple templates.
- Updated capi-single and capi-multiple to use modified images module.
- Pulled method for setting glabs link out into `ads` module, for more general usage.

There was also a corresponding endpoint added to frontend in [this](https://github.com/guardian/frontend/pull/14606) PR.

@JonNorman @Calum-Campbell @annebyrne @regiskuckaertz 