### PR TITLE
Apply fixes to Fabric Native

### DIFF
--- a/src/fabric-expandable/index.js
+++ b/src/fabric-expandable/index.js
@@ -30,7 +30,7 @@ function handleScroll() {
     } else if( scrollType === 'fixed' ) {
         sendMessage('fixed-background', { backgroundColour, backgroundImage: `url('${backgroundImage}')`, backgroundRepeat });
     } else {
-        sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat });
+        sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat, maxHeight: 500 });
     }
 }
 

--- a/src/fabric/index.html
+++ b/src/fabric/index.html
@@ -7,7 +7,7 @@
                     style="background-image: url('[%Layer1BackgroundImage%]');
                         background-position: [%Layer1BackgroundPosition%]"
                     ></div>
-                <div class="js-layer2 creative__layer creative__layer2 creative__layer2--animation-[%Layer2BackgroundAnimation%] creative__layer2--animation-pos-[%Layer2BackgroundAnimationPosition%]"
+                <div id="layer2" class="creative__layer creative__layer2 creative__layer2--animation-[%Layer2BackgroundAnimation%] creative__layer2--animation-pos-[%Layer2BackgroundAnimationPosition%]"
                     style="background-image: url('[%Layer2BackgroundImage%]')"
                     ></div>
                 <div class="creative__layer creative__layer3"

--- a/src/fabric/index.html
+++ b/src/fabric/index.html
@@ -1,4 +1,4 @@
-<div class="creative creative--fabric" style="background:[%BackgroundColour%]">
+<div class="creative creative--fabric">
     <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet"
         href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
         <div class="u-root">

--- a/src/fabric/index.html
+++ b/src/fabric/index.html
@@ -7,9 +7,8 @@
                     style="background-image: url('[%Layer1BackgroundImage%]');
                         background-position: [%Layer1BackgroundPosition%]"
                     ></div>
-                <div class="creative__layer creative__layer2"
-                    style="background-image: url('[%Layer2BackgroundImage%]');
-                        background-position: [%Layer2BackgroundPosition%]"
+                <div class="js-layer2 creative__layer creative__layer2 creative__layer2--animation-[%Layer2BackgroundAnimation%] creative__layer2--animation-pos-[%Layer2BackgroundAnimationPosition%]"
+                    style="background-image: url('[%Layer2BackgroundImage%]')"
                     ></div>
                 <div class="creative__layer creative__layer3"
                     style="background-image: url('[%Layer3BackgroundImage%]');

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -32,16 +32,18 @@ getIframeId()
 
         if( !isMobile ) {
             if( !onScrolling ) {
-                let layer2 = document.getElementsByClassName('js-layer2')[0];
                 onScrolling = true;
-                onScroll(({ top, bottom }) => {
-                    if( 0 < bottom && top < height ) {
-                        layer2.classList.add('is-animating');
-                        return false;
-                    }
-                });
-            } else {
-                write(() => layer2.style.backgroundPosition = '[%Layer2BackgroundPosition%]');
+                let layer2 = document.getElementById('layer2');
+                if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
+                    write(() => layer2.style.backgroundPosition = '[%Layer2BackgroundPosition%]');
+                } else {
+                    onScroll(({ top, bottom }) => {
+                        if( 0 <= top && bottom <= height ) {
+                            layer2.classList.add('is-animating');
+                            return false;
+                        }
+                    });
+                }
             }
         }
     });

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -27,7 +27,7 @@ getIframeId()
         } else if( scrollType === 'fixed' ) {
             sendMessage('fixed-background', { backgroundColour, backgroundImage: `url('${backgroundImage}')`, backgroundRepeat });
         } else {
-            sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat });
+            sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat, maxHeight: 500 });
         }
 
         if( !isMobile ) {

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -1,11 +1,12 @@
-import { getIframeId, resizeIframeHeight, sendMessage } from '../_shared/js/messages.js';
-import { write, div } from '../_shared/js/dom.js';
+import { getIframeId, resizeIframeHeight, onViewport, onScroll, sendMessage } from '../_shared/js/messages.js';
+import { write } from '../_shared/js/dom.js';
 
 getIframeId()
 .then(resizeIframeHeight)
 .then(() => {
     let scrollType = '[%ScrollType%]';
-    onViewport(({ width }) => {
+    let onScrolling = false;
+    onViewport(({ height, width }) => {
         let isMobile = width <= 739;
         let backgroundColour = '[%BackgroundColour%]';
         let [ backgroundImage, backgroundPosition, backgroundRepeat, creativeLink ] = isMobile ?
@@ -28,15 +29,20 @@ getIframeId()
         } else {
             sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat });
         }
+
+        if( !isMobile ) {
+            if( !onScrolling ) {
+                let layer2 = document.getElementsByClassName('js-layer2')[0];
+                onScrolling = true;
+                onScroll(({ top, bottom }) => {
+                    if( 0 < bottom && top < height ) {
+                        layer2.classList.add('is-animating');
+                        return false;
+                    }
+                });
+            } else {
+                write(() => layer2.style.backgroundPosition = '[%Layer2BackgroundPosition%]');
+            }
+        }
     });
 });
-
-function insertBgImage(creativeLink, backgroundImage, backgroundRepeat) {
-    let image = div({ className: 'creative__background' });
-    Object.assign(image.style, {
-        backgroundImage: `url('${backgroundImage}')`,
-        backgroundRepeat
-    });
-    creativeLink.insertBefore(image, creativeLink.firstChild);
-    return image;
-}

--- a/src/fabric/index.scss
+++ b/src/fabric/index.scss
@@ -25,8 +25,39 @@
     .creative__background {
         background-position: center;
     }
+
+    .creative__layer2--animation-enabled {
+        animation-play-state: running;
+        animation-duration: 1.4s;
+        animation-delay: .4s;
+        animation-timing-function: ease;
+        animation-fill-mode: forwards;
+        animation-play-state: paused;
+
+        &.creative__layer2--animation-pos-left   { animation-name: textanimation-left; background-position: left -250px; }
+        &.creative__layer2--animation-pos-centre { animation-name: textanimation-centre; background-position: center -250px; }
+        &.creative__layer2--animation-pos-right  { animation-name: textanimation-right; background-position: right -250px; }
+
+        &.is-animating {
+            animation-play-state: running;
+        }
+    }
 }
 
-.background-effect--fixed {
-    background-attachment: fixed;
+@keyframes textanimation-left {
+    0%   { background-position: 0 -250px; }
+    75%  { background-position: 0 0; }
+    100% { background-position: 0 0; }
+}
+
+@keyframes textanimation-right {
+    0%   { background-position: right -250px; }
+    75%  { background-position: right 0; }
+    100% { background-position: right 0; }
+}
+
+@keyframes textanimation-centre {
+    0%   { background-position: center -250px; }
+    75%  { background-position: center 0; }
+    100% { background-position: center 0; }
 }


### PR DESCRIPTION
Does ~~three~~ four things:

- uses the fixed/parallax background messages for smooth scrolling effects
- uses `onViewport` to get the correct dimensions of the parent frame, rather than a media query
- adds support for animation on the second layer
- sends the maximum height for the background image in the parallax mode