### PR TITLE
Fixes to the Fabric and Fabric expandable templates

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,6 +9,7 @@ let features = [
     'Element.prototype.closest',
     'Element.prototype.matches',
     'fetch',
+    'matchMedia',
     'Object.assign',
     'Promise',
     'requestAnimationFrame'

--- a/src/fabric-expandable/index.js
+++ b/src/fabric-expandable/index.js
@@ -10,6 +10,7 @@ getIframeId()
 
 function handleBackground() {
     let isMobile = window.matchMedia('(max-width: 739px)').matches;
+    let isTablet = window.matchMedia('(min-width: 740px) and (max-width: 979px)').matches;
     let scrollType = '[%ScrollType%]';
     let backgroundColour = '[%BackgroundColour%]';
     let [ backgroundImage, backgroundPosition, backgroundRepeat, creativeLink ] = isMobile ?
@@ -27,10 +28,14 @@ function handleBackground() {
                 backgroundRepeat
             });
         });
-    } else if( scrollType === 'fixed' ) {
-        sendMessage('fixed-background', { backgroundColour, backgroundImage: `url('${backgroundImage}')`, backgroundRepeat });
     } else {
-        sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat, maxHeight: 500 });
+        sendMessage('background', {
+            scrollType: scrollType === 'parallax' && (isMobile || isTablet) ? 'fixed' : scrollType,
+            backgroundColour,
+            backgroundImage: `url('${backgroundImage}')`,
+            backgroundRepeat,
+            backgroundPosition
+        });
     }
 }
 

--- a/src/fabric-expandable/index.js
+++ b/src/fabric-expandable/index.js
@@ -1,14 +1,14 @@
-import { getIframeId, resizeIframeHeight, sendMessage } from '../_shared/js/messages';
+import { getIframeId, sendMessage, resizeIframeHeight } from '../_shared/js/messages';
 import { enableToggles } from '../_shared/js/ui';
 import { write, div } from '../_shared/js/dom';
 
 getIframeId()
 .then(() => {
-    handleScroll();
+    handleBackground();
     handleToggle();
 });
 
-function handleScroll() {
+function handleBackground() {
     let isMobile = window.matchMedia('(max-width: 739px)').matches;
     let scrollType = '[%ScrollType%]';
     let backgroundColour = '[%BackgroundColour%]';

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -9,56 +9,53 @@ if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
 
 getIframeId()
 .then(() => {
-    let scrollType = '[%ScrollType%]';
-    let onScrolling = false;
-    let hasBackground = false;
+    let isMobile = window.matchMedia('(max-width: 739px)').matches;
+    let isTablet = window.matchMedia('(min-width: 740px) and (max-width: 979px)').matches;
 
-    onViewport(({ height, width }) => {
-        let isMobile = width < 740;
-        let isTablet = !isMobile && width < 980;
+    handleBackground(isMobile, isTablet);
 
-        handleBackground(isMobile, isTablet);
-        handleLayer2(isMobile, height);
-    });
-
-    function handleBackground(isMobile, isTablet) {
-        if( !hasBackground ) {
-            hasBackground = true;
-            let backgroundColour = '[%BackgroundColour%]';
-            let [ backgroundImage, backgroundPosition, backgroundRepeat, creativeLink ] = isMobile ?
-                ['[%MobileBackgroundImage%]', '[%MobileBackgroundImagePosition%]', '[%MobileBackgroundImageRepeat%]', document.getElementById('linkMobile')] :
-                ['[%BackgroundImage%]', '[%BackgroundImagePosition%]', '[%BackgroundImageRepeat%]', document.getElementById('linkDesktop')];
-
-            if( !backgroundImage ) return;
-
-            if( scrollType === 'none' ) {
-                write(() => {
-                    document.documentElement.style.backgroundColor = backgroundColour;
-                    Object.assign(creativeLink.style, {
-                        backgroundImage: `url('${backgroundImage}')`,
-                        backgroundPosition,
-                        backgroundRepeat
-                    })
-                });
-            } else if( scrollType === 'fixed' || (scrollType === 'parallax' && (isMobile || isTablet)) ) {
-                sendMessage('fixed-background', { backgroundColour, backgroundImage: `url('${backgroundImage}')`, backgroundRepeat });
-            } else {
-                sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat, maxHeight: 500 });
-            }
-        }
-    }
-
-    function handleLayer2(isMobile, height) {
-        if( !isMobile ) {
-            if( !onScrolling && layer2.classList.contains('creative__layer2--animation-enabled') ) {
-                onScrolling = true;
-                onScroll(({ top, bottom }) => {
-                    if( 0 <= top && bottom <= height ) {
-                        layer2.classList.add('is-animating');
-                        return false;
-                    }
-                });
-            }
-        }
+    if( !isMobile && layer2.classList.contains('creative__layer2--animation-enabled') ) {
+        onViewport(({ height }) => {
+            handleLayer2(height);
+            return false;
+        });
     }
 });
+
+function handleBackground(isMobile, isTablet) {
+    let scrollType = '[%ScrollType%]';
+    let backgroundColour = '[%BackgroundColour%]';
+    let [ backgroundImage, backgroundPosition, backgroundRepeat, creativeLink ] = isMobile ?
+        ['[%MobileBackgroundImage%]', '[%MobileBackgroundImagePosition%]', '[%MobileBackgroundImageRepeat%]', document.getElementById('linkMobile')] :
+        ['[%BackgroundImage%]', '[%BackgroundImagePosition%]', '[%BackgroundImageRepeat%]', document.getElementById('linkDesktop')];
+
+    if( !backgroundImage ) return;
+
+    if( scrollType === 'none' ) {
+        write(() => {
+            document.documentElement.style.backgroundColor = backgroundColour;
+            Object.assign(creativeLink.style, {
+                backgroundImage: `url('${backgroundImage}')`,
+                backgroundPosition,
+                backgroundRepeat
+            })
+        });
+    } else {
+        sendMessage('background', {
+            scrollType: scrollType === 'parallax' && (isMobile || isTablet) ? 'fixed' : scrollType,
+            backgroundColour,
+            backgroundImage: `url('${backgroundImage}')`,
+            backgroundRepeat,
+            backgroundPosition
+        });
+    }
+}
+
+function handleLayer2(height) {
+    onScroll(({ top, bottom }) => {
+        if( 0 <= top && bottom <= height ) {
+            layer2.classList.add('is-animating');
+            return false;
+        }
+    });
+}

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -32,7 +32,7 @@ getIframeId()
 
             if( !backgroundImage ) return;
 
-            if( scrollType === 'none' || isMobile || isTablet ) {
+            if( scrollType === 'none' ) {
                 write(() => {
                     document.documentElement.style.backgroundColor = backgroundColour;
                     Object.assign(creativeLink.style, {
@@ -41,7 +41,7 @@ getIframeId()
                         backgroundRepeat
                     })
                 });
-            } else if( scrollType === 'fixed' ) {
+            } else if( scrollType === 'fixed' || (scrollType === 'parallax' && (isMobile || isTablet)) ) {
                 sendMessage('fixed-background', { backgroundColour, backgroundImage: `url('${backgroundImage}')`, backgroundRepeat });
             } else {
                 sendMessage('parallax-background', { backgroundColour, backgroundImage: backgroundImage, backgroundRepeat, maxHeight: 500 });

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -1,4 +1,4 @@
-import { getIframeId, resizeIframeHeight, onViewport, onScroll, sendMessage } from '../_shared/js/messages.js';
+import { getIframeId, onViewport, onScroll, sendMessage } from '../_shared/js/messages.js';
 import { write } from '../_shared/js/dom.js';
 
 let layer2 = document.getElementById('layer2');
@@ -8,7 +8,6 @@ if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
 }
 
 getIframeId()
-.then(resizeIframeHeight)
 .then(() => {
     let scrollType = '[%ScrollType%]';
     let onScrolling = false;

--- a/src/fabric/index.js
+++ b/src/fabric/index.js
@@ -15,13 +15,14 @@ getIframeId()
     let hasBackground = false;
 
     onViewport(({ height, width }) => {
-        let isMobile = width <= 739;
+        let isMobile = width < 740;
+        let isTablet = !isMobile && width < 980;
 
-        handleBackground(isMobile);
+        handleBackground(isMobile, isTablet);
         handleLayer2(isMobile, height);
     });
 
-    function handleBackground(isMobile) {
+    function handleBackground(isMobile, isTablet) {
         if( !hasBackground ) {
             hasBackground = true;
             let backgroundColour = '[%BackgroundColour%]';
@@ -31,7 +32,7 @@ getIframeId()
 
             if( !backgroundImage ) return;
 
-            if( scrollType === 'none' ) {
+            if( scrollType === 'none' || isMobile || isTablet ) {
                 write(() => {
                     document.documentElement.style.backgroundColor = backgroundColour;
                     Object.assign(creativeLink.style, {


### PR DESCRIPTION
The fixed/parallax scroll effects had some problems that the DAP team reported. I fixed these in this PR.
- use media queries to detect mobile/tablet environments
- unify background message
- simplify persistent listeners logic

This PR is linked to [this one](https://github.com/guardian/frontend/pull/14806).
