### PR TITLE
Layout fixes in Safari, IE et al

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -1,12 +1,21 @@
 const spawn = require('./task');
 const csso = require('csso');
 const Promise = require('bluebird');
+const postcss = require('postcss');
+const autoprefixer = require('autoprefixer');
 const renderSass = Promise.promisify(require('node-sass').render);
 
 function buildCss(fs, src, dst) {
     return spawn(function*() {
         const exists = yield fs.statAsync(src).then(() => true).catch(() => false);
-        const css = exists ? compressCss(yield compileSass(src)) : '';
+        let css = '';
+
+        if( exists ) {
+            let compiledSass = yield compileSass(src);
+            css = yield postprocessCss(compiledSass);
+            css = compressCss(css);
+        }
+
         return fs.writeFileAsync(dst, css);
     });
 }
@@ -22,6 +31,25 @@ function compileSass(file) {
             ]
         });
         return sass.css.toString();
+    });
+}
+
+function postprocessCss(css) {
+    var modernBrowsers = [
+        'last 2 versions',
+        'Firefox ESR',
+
+        'Android >= 4',
+        'BlackBerry >= 6',
+
+        '> 2% in US',
+        '> 2% in AU',
+        '> 2% in GB'
+    ];
+
+    return spawn(function* () {
+        let result = yield postcss([ autoprefixer({ browsers: modernBrowsers }) ]).process(css);
+        return result.css;
     });
 }
 

--- a/lib/css.js
+++ b/lib/css.js
@@ -38,6 +38,7 @@ function postprocessCss(css) {
     var modernBrowsers = [
         'last 2 versions',
         'Firefox ESR',
+        'Safari >= 8',
 
         'Android >= 4',
         'BlackBerry >= 6',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sass-mq": "^3.2.9"
   },
   "devDependencies": {
-    "autoprefixer": "^6.3.7",
+    "autoprefixer": "^6.5.1",
     "babel-core": "^6.13.2",
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-preset-es2015": "^6.13.2",
@@ -18,6 +18,7 @@
     "express": "^4.13.3",
     "hogan.js": "^3.0.2",
     "node-sass": "^3.8.0",
+    "postcss": "^5.2.5",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "rimraf": "^2.5.4",

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -96,7 +96,7 @@ function getWebfonts(fontFamilies) {
 
 function resizeIframeHeight(height = -1) {
     return height === -1 ?
-        Promise.all(areImagesLoaded().concat(isDocumentLoaded()))
+        timeout(Promise.all(areImagesLoaded().concat(isDocumentLoaded())), 3000)
         .then(() => read(() => document.body.getBoundingClientRect().height))
         .then(function(height) {
             return sendMessage('resize', { height });

--- a/src/_shared/scss/_advert.scss
+++ b/src/_shared/scss/_advert.scss
@@ -102,6 +102,10 @@
     }
 }
 
+.advert__text {
+    max-width: 100%;
+}
+
 .advert__title {
     font-size: 1rem;
     line-height: 1.25;

--- a/src/_shared/scss/_advert.scss
+++ b/src/_shared/scss/_advert.scss
@@ -126,7 +126,7 @@
     width: 100%;
 
     @include mq(tablet) {
-        height: 11 * $gs-baseline;
+        max-height: 11 * $gs-baseline;
     }
 
     .has-no-flex & {
@@ -138,15 +138,13 @@
     }
 
     .advert-blended__body & {
-        height: auto;
+        max-height: none;
     }
 }
 
 .advert__image {
     display: block;
     max-width: 100%;
-    max-height: 100%;
-    height: auto;
 }
 
 .advert__meta {
@@ -188,7 +186,7 @@
         > .advert__image-container {
             flex-basis: calc(50% - #{$gs-gutter / 2});
             flex-shrink: 0;
-            height: auto;
+            max-height: none;
             order: 0;
             margin-bottom: 0;
             margin-right: $gs-gutter / 2;

--- a/src/travel/test.json
+++ b/src/travel/test.json
@@ -1,6 +1,6 @@
 {
 	"TrackingId": "test-id",
-	"NumberofCards": "4",
-	"IsProminent": "false",
+	"NumberofCards": "3",
+	"IsProminent": "true",
 	"IDs": ""
 }


### PR DESCRIPTION
@ScottPainterGNM reported many issues in the native travel component that were all related to the same causes:

1- the CSS was not post-processed to include prefixes for older browsers
2- the promise waiting for images to load never resolved, resulting in ads that appeared cut through

This PR addresses these issues, which are shared across all templates.