### PR TITLE
Making place for AMP creatives

### DIFF
--- a/build.js
+++ b/build.js
@@ -13,8 +13,9 @@ let features = [
     'Object.assign',
     'Promise',
     'requestAnimationFrame'
-]
-const options = {
+];
+
+let options = {
     banner: `
         <base target="_blank" href="https://www.theguardian.com">
         <script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=${features.join(',')}"></script>

--- a/lib/build.js
+++ b/lib/build.js
@@ -32,9 +32,19 @@ function build(options) {
             }
             prefix += `${dir}/`;
         });
+
+        let mode = dir.substr(dir.lastIndexOf('/') + 1);
+        let opts = Object.assign({ mode }, options);
+
         return [
-            buildCss(fs, `${src}/${dir}/index.scss`, `${dst}/${dir}/index.css`),
-            spawn(function*() { return buildHtml(fs, `${src}/${dir}/index.html`, yield buildJs(`${src}/${dir}/index.js`, minify), `${dst}/${dir}/index.html`, options) })
+            buildCss(fs, `${src}/${dir}/index.scss`, `${dst}/${dir}/index.css`, opts),
+            spawn(function*() { return buildHtml(
+                fs,
+                `${src}/${dir}/index.html`,
+                yield buildJs(`${src}/${dir}/index.js`, opts),
+                `${dst}/${dir}/index.html`,
+                opts
+            ) })
         ];
     }));
 }

--- a/lib/css.js
+++ b/lib/css.js
@@ -3,16 +3,16 @@ const csso = require('csso');
 const Promise = require('bluebird');
 const postcss = require('postcss');
 const autoprefixer = require('autoprefixer');
-const renderSass = Promise.promisify(require('node-sass').render);
+const sass = require('node-sass');
+const renderSass = Promise.promisify(sass.render);
 
-function buildCss(fs, src, dst) {
+function buildCss(fs, src, dst, { mode = 'web' } = {}) {
     return spawn(function*() {
-        const exists = yield fs.statAsync(src).then(() => true).catch(() => false);
-        let css = '';
+        let css;
 
-        if( exists ) {
-            let compiledSass = yield compileSass(src);
-            css = yield postprocessCss(compiledSass);
+        css = yield compileSass(src);
+        if( mode !== 'amp' ) {
+            css = yield postprocessCss(css);
             css = compressCss(css);
         }
 
@@ -22,15 +22,20 @@ function buildCss(fs, src, dst) {
 
 function compileSass(file) {
     return spawn(function* () {
-        const sass = yield renderSass({
+        const compiled = yield renderSass({
             file,
             sourceMap: false,
             includePaths: [
                 'src/_shared/scss',
                 'node_modules/sass-mq'
-            ]
+            ],
+            functions: {
+                'dfpVar($var)': function (varName) {
+                    return new sass.types.String(`[%${varName.getValue()}%]`);
+                }
+            }
         });
-        return sass.css.toString();
+        return compiled.css.toString();
     });
 }
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,7 +1,7 @@
 const spawn = require('./task');
 const hogan = require('hogan.js');
 
-function buildHtml(fs, src, js, dst, { banner = '', footer = '' } = {}) {
+function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } = {}) {
     const partials = {
         svg: () => (text, render) => {
             const svgName = text.trim();
@@ -22,15 +22,15 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '' } = {}) {
 
               min_ages = [];
               for(var age = 18; age < 100; age++) {
-                min_ages.push({age: age, selected_default: age === 25});
+                min_ages.push({ age, selected_default: age === 25});
               }
 
               max_ages = [];
               for(var age = 18; age < 100; age++) {
-                max_ages.push({age: age, selected_default: age === 45});
+                max_ages.push({ age, selected_default: age === 45});
               }
 
-            return {min_ages: min_ages, max_ages: max_ages};
+            return { min_ages, max_ages };
           }
       )()
     };
@@ -38,8 +38,8 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '' } = {}) {
     return spawn(function* () {
         const dst = src.replace('src', 'build');
         const template = yield fs.readFileAsync(src, 'utf8');
-        const html = banner + hogan.compile(template).render(partials) + footer;
-        return fs.writeFileAsync(dst, `${html}\n<script>${js}</script>`);
+        const html = (mode === 'amp' ? '' : banner) + hogan.compile(template).render(partials) + footer;
+        return fs.writeFileAsync(dst, mode === 'amp' ? html : `${html}\n<script>${js}</script>`);
     });
 }
 

--- a/lib/js.js
+++ b/lib/js.js
@@ -3,7 +3,7 @@ const rollup = require('rollup');
 const babel = require('rollup-plugin-babel');
 const uglify = require('uglify-js');
 
-function buildJs(src, minify) {
+function buildJs(src, { minify, mode }) {
     return spawn(function*() {
         const bundle = yield rollup.rollup({ entry: src, plugins: [ babel() ] });
         const code = bundle.generate({

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
     "hogan.js": "^3.0.2",
     "node-sass": "^3.8.0",
     "postcss": "^5.2.5",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
     "rimraf": "^2.5.4",
-    "rollup": "^0.34.1",
+    "rollup": "^0.36.3",
     "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-commonjs": "^4.1.0",
+    "rollup-plugin-commonjs": "^5.0.5",
     "rollup-plugin-jsx": "^1.0.3",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "uglify-js": "^2.7.0",
-    "yargs": "^5.0.0"
+    "yargs": "^6.3.0"
   },
   "scripts": {
     "clean": "node clean.js",

--- a/src/_shared/scss/_core.scss
+++ b/src/_shared/scss/_core.scss
@@ -67,14 +67,14 @@ $creative-max-width: 1920px;
 }
 
 .u-h {
-    border: 0 !important;
-    clip: rect(0 0 0 0) !important;
-    height: 1px !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: absolute !important;
-    width: 1px !important;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
 }
 
 .u-fauxlink {
@@ -228,14 +228,14 @@ $creative-max-width: 1920px;
 
 // Hide content visually, still readable by screen readers
 @mixin u-h {
-    border: 0 !important;
-    clip: rect(0 0 0 0) !important;
-    height: 1px !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: absolute !important;
-    width: 1px !important;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
 }
 
 @mixin f-textSans {

--- a/src/_shared/scss/_helpers.scss
+++ b/src/_shared/scss/_helpers.scss
@@ -1,18 +1,18 @@
 .hide-until-tablet {
     @include mq($until: tablet) {
-        display: none !important;
+        display: none;
     }
 }
 
 .hide-until-mobile-landscape {
     @include mq($until: mobileLandscape) {
-        display: none !important;
+        display: none;
     }
 }
 
 .mobile-only {
     @include mq(tablet) {
-        display: none !important;
+        display: none;
     }
 }
 

--- a/src/fabric/amp/index.html
+++ b/src/fabric/amp/index.html
@@ -1,14 +1,5 @@
 <div class="creative creative--fabric">
-    <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-        <div class="u-root">
-            <div class="creative__alt creative__alt--tablet">
-                <div class="creative__layer creative__layer1"></div>
-                <div id="layer2" class="creative__layer creative__layer2 creative__layer2--animation-[%Layer2BackgroundAnimation%] creative__layer2--animation-pos-[%Layer2BackgroundAnimationPosition%]"></div>
-                <div class="creative__layer creative__layer3"></div>
-            </div>
-        </div>
-    </a>
-    <a id="linkMobile" class="blink gs-container creative__link mobile-only" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+    <a class="blink gs-container creative__link" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
         <div class="u-root">
             <div class="creative__alt creative__alt--mobile">
                 <div class="creative__layer creative__layer1"></div>

--- a/src/fabric/amp/index.html
+++ b/src/fabric/amp/index.html
@@ -1,0 +1,21 @@
+<div class="creative creative--fabric">
+    <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+        <div class="u-root">
+            <div class="creative__alt creative__alt--tablet">
+                <div class="creative__layer creative__layer1"></div>
+                <div id="layer2" class="creative__layer creative__layer2 creative__layer2--animation-[%Layer2BackgroundAnimation%] creative__layer2--animation-pos-[%Layer2BackgroundAnimationPosition%]"></div>
+                <div class="creative__layer creative__layer3"></div>
+            </div>
+        </div>
+    </a>
+    <a id="linkMobile" class="blink gs-container creative__link mobile-only" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+        <div class="u-root">
+            <div class="creative__alt creative__alt--mobile">
+                <div class="creative__layer creative__layer1"></div>
+                <div class="creative__layer creative__layer2"></div>
+                <div class="creative__layer creative__layer3"></div>
+            </div>
+        </div>
+    </a>
+</div>
+<amp-pixel src="[%Trackingpixel%]?RANDOM"></amp-pixel>

--- a/src/fabric/amp/index.js
+++ b/src/fabric/amp/index.js
@@ -1,0 +1,13 @@
+import { write } from '../../_shared/js/dom.js';
+
+let layer2 = document.getElementById('layer2');
+
+if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
+    write(() => layer2.style.backgroundPosition = '[%Layer2BackgroundPosition%]');
+}
+
+let isMobile = window.matchMedia('(max-width: 739px)').matches;
+
+if( !isMobile && layer2.classList.contains('creative__layer2--animation-enabled') ) {
+    layer2.classList.add('is-animating');
+}

--- a/src/fabric/amp/index.scss
+++ b/src/fabric/amp/index.scss
@@ -1,0 +1,63 @@
+@import '_core';
+
+.creative--fabric,
+.creative__link {
+    height: 250px;
+    overflow: hidden;
+}
+
+.creative__layer1 { z-index: 1; }
+.creative__layer2 { z-index: 2; }
+.creative__layer3 { z-index: 3; }
+
+.creative__background,
+.creative__alt,
+.creative__layer {
+    width: 100%;
+    height: 250px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-repeat: no-repeat;
+}
+
+.creative__background {
+    background-position: center;
+}
+
+#linkDesktop {
+    background: dfpVar(BackgroundColour) url('#{dfpVar(BackgroundImage)}') dfpVar(BackgroundImageRepeat) dfpVar(BackgroundImagePosition);
+}
+
+#linkDesktop .creative__layer1 {
+    background-image: url('#{dfpVar(Layer1BackgroundImage)}');
+    background-position: dfpVar(Layer1BackgroundPosition);
+}
+
+#linkDesktop .creative__layer2 {
+    background-image: url('#{dfpVar(Layer2BackgroundImage)}');
+}
+
+#linkDesktop .creative__layer3 {
+    background-image: url('#{dfpVar(Layer3BackgroundImage)}');
+    background-position: dfpVar(Layer3BackgroundPosition);
+}
+
+#linkMobile {
+    background: dfpVar(BackgroundColour) url('#{dfpVar(MobileBackgroundImage)}') dfpVar(MobileBackgroundImageRepeat) dfpVar(MobileBackgroundImagePosition);
+}
+
+#linkMobile .creative__layer1 {
+    background-image: url('#{dfpVar(MobileLayer1BackgroundImage)}');
+    background-position: dfpVar(MobileLayer1BackgroundPosition);
+}
+
+#linkMobile .creative__layer2 {
+    background-image: url('#{dfpVar(MobileLayer2BackgroundImage)}');
+    background-position: dfpVar(MobileLayer2BackgroundPosition);
+}
+
+#linkMobile .creative__layer3 {
+    background-image: url('#{dfpVar(MobileLayer3BackgroundImage)}');
+    background-position: dfpVar(MobileLayer3BackgroundPosition);
+}

--- a/src/fabric/amp/index.scss
+++ b/src/fabric/amp/index.scss
@@ -25,39 +25,21 @@
     background-position: center;
 }
 
-#linkDesktop {
-    background: dfpVar(BackgroundColour) url('#{dfpVar(BackgroundImage)}') dfpVar(BackgroundImageRepeat) dfpVar(BackgroundImagePosition);
-}
-
-#linkDesktop .creative__layer1 {
-    background-image: url('#{dfpVar(Layer1BackgroundImage)}');
-    background-position: dfpVar(Layer1BackgroundPosition);
-}
-
-#linkDesktop .creative__layer2 {
-    background-image: url('#{dfpVar(Layer2BackgroundImage)}');
-}
-
-#linkDesktop .creative__layer3 {
-    background-image: url('#{dfpVar(Layer3BackgroundImage)}');
-    background-position: dfpVar(Layer3BackgroundPosition);
-}
-
-#linkMobile {
+.creative__link {
     background: dfpVar(BackgroundColour) url('#{dfpVar(MobileBackgroundImage)}') dfpVar(MobileBackgroundImageRepeat) dfpVar(MobileBackgroundImagePosition);
 }
 
-#linkMobile .creative__layer1 {
+.creative__layer1 {
     background-image: url('#{dfpVar(MobileLayer1BackgroundImage)}');
     background-position: dfpVar(MobileLayer1BackgroundPosition);
 }
 
-#linkMobile .creative__layer2 {
+.creative__layer2 {
     background-image: url('#{dfpVar(MobileLayer2BackgroundImage)}');
     background-position: dfpVar(MobileLayer2BackgroundPosition);
 }
 
-#linkMobile .creative__layer3 {
+.creative__layer3 {
     background-image: url('#{dfpVar(MobileLayer3BackgroundImage)}');
     background-position: dfpVar(MobileLayer3BackgroundPosition);
 }

--- a/src/fabric/app/index.js
+++ b/src/fabric/app/index.js
@@ -1,4 +1,3 @@
-import { getIframeId, onViewport, onScroll, sendMessage, resizeIframeHeight } from '../../_shared/js/messages.js';
 import { write } from '../../_shared/js/dom.js';
 
 let layer2 = document.getElementById('layer2');


### PR DESCRIPTION
So, AMP is very specific in that:

- we can't use JavaScript: this severely limits the scope of each template to be essentially empty HTML fragments with DFP placeholders
- we can't use `style` attributes: that means moving all the style-related variables into the CSS
- AMP is for mobile only so all the desktop stuff can go away
- Finally, the `!important` keyword is forbidden in AMP... I don't know why

As a result I had to change the build process, which is the point of this PR. It also adds a Fabric for AMP for testing purposes.

(As a corollary, a much better build process will be written at some point in the future. It is good enough now. For example, we could use UNCSS to remove all the unnecessary styles for a specific template.)
