### PR TITLE
Fix misspelled class name

### DIFF
--- a/src/manual-inline/web/index.html
+++ b/src/manual-inline/web/index.html
@@ -1,4 +1,4 @@
-<aside class="adverts adverts--manual adverts--legacy-inline adverts--[%Tone%] adverts--tone-[%Tone%]" data-link-name="creative | manual inline | [%TrackingId%]">
+<aside class="adverts adverts--manual adverts--legacy-inline adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual inline | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">
             <a class="adverts__logo blink" href="%%CLICK_URL_UNESC%%[%BaseUrl%]" data-link-name="title">


### PR DESCRIPTION
The manual inline component did not abide _by the law_ that the class names in `adverts` components must be pluralised..

