### PR TITLE
Fix the height of the books component and make them centred

### DIFF
--- a/src/_shared/scss/_adverts-books.scss
+++ b/src/_shared/scss/_adverts-books.scss
@@ -73,6 +73,44 @@
         }
     }
 
+    &.advert--prominent-true > .advert__image-container {
+        flex-basis: calc(66.67% - #{$gs-gutter / 2});
+    }
+
+    &.has-no-flex {
+        .advert--prominent-true > .advert__image-container {
+            width:  calc(66.67% - #{$gs-gutter / 2});
+        }
+
+        .advert--prominent-true > .advert__text {
+            width:  calc(33.33% - #{$gs-gutter / 2});
+        }
+    }
+
+    &.advert--prominent-false {
+      .advert__image-container {
+        align-self: center;
+        width: auto;
+      }
+      .advert__image {
+        width: auto;
+        max-height: 150px;
+      }
+    }
+
+    .adverts__row--prominent-true &.advert--prominent-false {
+      .advert__image {
+        max-height: 300px;
+      }
+    }
+
+    &.advert--prominent-true {
+      & .advert__image {
+        max-height: 450px;
+        width: auto;
+      }
+    }
+
     &.adverts--legacy-inline {
         @include mq(mobileLandscape) {
             width: gs-span(2);

--- a/src/_shared/scss/_adverts-books.scss
+++ b/src/_shared/scss/_adverts-books.scss
@@ -73,20 +73,6 @@
         }
     }
 
-    &.advert--prominent-true > .advert__image-container {
-        flex-basis: calc(66.67% - #{$gs-gutter / 2});
-    }
-
-    &.has-no-flex {
-        .advert--prominent-true > .advert__image-container {
-            width:  calc(66.67% - #{$gs-gutter / 2});
-        }
-
-        .advert--prominent-true > .advert__text {
-            width:  calc(33.33% - #{$gs-gutter / 2});
-        }
-    }
-
     &.advert--prominent-false {
       .advert__image-container {
         align-self: center;
@@ -100,6 +86,7 @@
 
     .adverts__row--prominent-true &.advert--prominent-false {
       .advert__image {
+        width: auto;
         max-height: 300px;
       }
     }

--- a/src/books/test.json
+++ b/src/books/test.json
@@ -1,6 +1,6 @@
 {
 	"TrackingId": "test-id",
-	"NumberofCards": "3",
+	"NumberofCards": "4",
 	"IsProminent": "true",
-	"ISBNs": ""
+	"ISBNs": "9780751565355,9781405277334,9780718184353,9781910749272"
 }


### PR DESCRIPTION
### Background
The cards within the books native component currently have no maximum height, which can lead to inconsistent looking book covers.

### Changes
This PR provides a maximum height to the cards and centres them within the image containers.

### Screenshots
**Non prominent (old)**
![image](https://cloud.githubusercontent.com/assets/1821099/20557860/364457c0-b165-11e6-80c4-c2dde542f7ce.png)

**Non prominent (updated)**
![image](https://cloud.githubusercontent.com/assets/1821099/20557867/3a3e381e-b165-11e6-86ae-2dbae004c13c.png)

**Prominent (old)**
![image](https://cloud.githubusercontent.com/assets/1821099/20557871/3e8e6628-b165-11e6-8c00-f368ea23194e.png)

**Prominent (updated)**
![image](https://cloud.githubusercontent.com/assets/1821099/20557872/42203956-b165-11e6-8ad2-f3305fdce302.png)

### Request for feedback
@guardian/commercial-dev 