### PR TITLE
CAPI multiple: Update mobile breakpoint design to fit the spec

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -100,10 +100,7 @@ function buildCard (cardInfo, cardNum, isPaid) {
 
     imgContainer.insertAdjacentHTML('afterbegin', image);
 
-    // Only first two cards show on mobile portrait.
-    if (cardNum >= 3) {
-        card.classList.add('hide-until-tablet');
-    } else if (cardNum > 0) {
+    if (cardNum > 0) {
         imgContainer.classList.add('hide-until-tablet');
     }
 

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -101,8 +101,10 @@ function buildCard (cardInfo, cardNum, isPaid) {
     imgContainer.insertAdjacentHTML('afterbegin', image);
 
     // Only first two cards show on mobile portrait.
-    if (cardNum >= 2) {
+    if (cardNum >= 3) {
         card.classList.add('hide-until-tablet');
+    } else if (cardNum > 0) {
+        imgContainer.classList.add('hide-until-tablet');
     }
 
     return cardFragment;

--- a/src/_shared/scss/_adverts-capi.scss
+++ b/src/_shared/scss/_adverts-capi.scss
@@ -2,6 +2,29 @@
     .adverts__title {
         font-size: get-font-size(headline, 3);
     }
+
+    .adverts__row {
+        @include mq($until: tablet) {
+            flex-direction: column;
+
+            & > * {
+                flex-basis: auto;
+            }
+
+            & > * + * {
+                margin-top: $gs-baseline;
+            }
+
+            & > * + .advert {
+                padding-top: $gs-baseline / 2;
+            }
+
+            & > * + :nth-child(even)::before {
+                content: none;
+            }
+        }
+    }
+
 }
 
 .adverts--paidfor {

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -1,6 +1,6 @@
 {
     "ComponentTitle": "Led Zeppelin special",
-    "SeriesURL": "spotify-discover-weekly/spotify-discover-weekly",
+    "SeriesURL": "music/ledzeppelin",
     "Brand": "Unilever",
     "BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
     "TrackingID": "1234",

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -18,3 +18,12 @@
     width: 75px;
     max-height: 31px;
 }
+
+.adverts__stamp {
+    @include mq($until: tablet) {
+        position: absolute;
+        right: $gs-gutter / 2;
+        top: $gs-baseline / 2;
+    }
+
+}


### PR DESCRIPTION
On mobile, we should only show one article with a pic, followed by two without beneath it.

![localhost-7000- iphone 6 plus 1](https://cloud.githubusercontent.com/assets/629976/20833534/2d5e9876-b888-11e6-8a5f-c828443ebdb3.png)
![localhost-7000- iphone 6 plus](https://cloud.githubusercontent.com/assets/629976/20833535/2d5f0a7c-b888-11e6-941f-4e24943def17.png)

@ScottPainterGNM 