### PR TITLE
Capi multiple fix

### DIFF
--- a/src/capi-multiple-hosted/test.json
+++ b/src/capi-multiple-hosted/test.json
@@ -1,6 +1,6 @@
 {
     "ComponentTitle": "Led Zeppelin special",
-    "SeriesURL": "advertiser-content/lloyds-bank-wealth/lloyds-bank-wealth",
+    "SeriesURL": "advertiser-content/discover-cool-canada/discover-cool-canada",
     "BrandColour": "#024731",
     "BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
     "numberOfElements": "4",

--- a/src/capi-multiple-hosted/web/index.js
+++ b/src/capi-multiple-hosted/web/index.js
@@ -1,5 +1,21 @@
 import capiMultiple from '../../_shared/js/capi-multiple.js';
 import addColourContrastClass from '../../_shared/js/hosted-colours.js';
 
-capiMultiple("hosted")
+
+const OVERRIDES = {
+    kickers: ['[%Article1Kicker%]', '[%Article2Kicker%]', '[%Article3Kicker%]', '[%Article4Kicker%]']
+};
+
+// Constructs the kicker text
+function buildKicker (card, cardNumber) {
+
+    let kicker = card.querySelector('.advert__kicker');
+    let kickerText = OVERRIDES.kickers[cardNumber];
+
+    if(kicker && kickerText){
+        kicker.textContent = kickerText + " / ";
+    }
+}
+
+capiMultiple("hosted", buildKicker)
     .then(() => addColourContrastClass());


### PR DESCRIPTION
Removes some hosted-specific code from the shared js.

DFP doesn't let you save if there are variables in the html that are not defined for that template. Only the Hosted one uses kickers.