### PR TITLE
CAPI multiple: Add an optional brand logo to each card

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -83,13 +83,13 @@ function importCard (adType) {
 }
 
 // Constructs an individual card.
-function buildCard (cardInfo, cardNum, adType, modifyCardFn) {
+function buildCard (cardInfo, cardNum, adType, cardsInfo, modifyCardFn) {
 
     let cardFragment = importCard(adType);
     let card = cardFragment.querySelector(`.advert--${adType}`);
     let imgContainer = card.querySelector('.advert__image-container');
 
-    modifyCardFn && modifyCardFn(card, cardNum, cardInfo);
+    modifyCardFn && modifyCardFn(card, cardNum, cardsInfo);
     buildTitle(card, cardInfo, cardNum);
     card.href = clickMacro + cardInfo.articleUrl;
 
@@ -134,9 +134,13 @@ function buildFromCapi (host, cardsInfo, adType, modifyCardFn) {
 
     let cardList = document.createDocumentFragment();
 
+    cardsInfo.isSingle = cardsInfo.articles
+    .map(cardInfo => cardInfo.branding.sponsorLogo.url)
+    .reduce(((isSingle, url, index, urls) => isSingle && (index === 0 || url === urls[index - 1])), true);
+
     // Constructs an array of cards from an array of data.
     cardsInfo.articles.forEach((info, idx) => {
-        cardList.appendChild(buildCard(info, idx, adType, modifyCardFn));
+        cardList.appendChild(buildCard(info, idx, adType, cardsInfo, modifyCardFn));
     });
 
     return write(() => {

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -112,12 +112,19 @@ function buildCard (cardInfo, cardNum, adType, cardsInfo, modifyCardFn) {
 // Adds branding information from cAPI or DFP override.
 function addBranding (brandingCard) {
 
-    let brandImage = document.querySelector('.badge__logo');
+    let body = document.querySelector('.adverts__body');
+    let logoUrl = OVERRIDES.brandLogo || brandingCard.branding.sponsorLogo.url;
 
-    if (OVERRIDES.brandLogo === '') {
-        brandImage.src = brandingCard.branding.sponsorLogo.url;
-    }
+    body.insertAdjacentHTML('beforeend', generateLogo(logoUrl));
+}
 
+function generateLogo(logoUrl) {
+    return `<div class="badge">
+        Paid for by
+        <a class="badge__link" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesURL%]" data-link-name="badge" target="_top">
+            <img class="badge__logo" src="${logoUrl}" alt="">
+        </a>
+    </div>`
 }
 
 // Sets correct glabs link based on edition (AU/All others).
@@ -145,7 +152,7 @@ function buildFromCapi (host, cardsInfo, adType, modifyCardFn) {
 
     return write(() => {
         // Takes branding from last possible card, in case earlier ones overriden.
-        addBranding(cardsInfo.articles.slice(-1)[0]);
+        if( cardsInfo.isSingle ) addBranding(cardsInfo.articles.slice(-1)[0]);
         let advertRow = document.querySelector('.adverts__row');
         advertRow.appendChild(cardList);
         editionLink(host, cardsInfo.articles[0].edition, adType);

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -89,7 +89,7 @@ function buildCard (cardInfo, cardNum, adType, modifyCardFn) {
     let card = cardFragment.querySelector(`.advert--${adType}`);
     let imgContainer = card.querySelector('.advert__image-container');
 
-    modifyCardFn && modifyCardFn(card, cardNum);
+    modifyCardFn && modifyCardFn(card, cardNum, cardInfo);
     buildTitle(card, cardInfo, cardNum);
     card.href = clickMacro + cardInfo.articleUrl;
 

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -551,6 +551,12 @@
     }
 }
 
+.badge--branded {
+    margin-top: auto;
+    margin-left: auto;
+    padding-right: $gs-gutter / 4;
+}
+
 .badge__logo {
     max-height: $gs-baseline * 5;
     margin-left: $gs-gutter / 2;

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -7,24 +7,16 @@
     "Article1Headline": "It's time for the NHS to realise the benefits of digital",
     "Article1URL": "p/52efd",
     "Article1Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL8_aZahABGAEyCM7vHR3kurK0",
-    "Article1Logo": "",
-    "Article1LogoUrl": "",
 
-    "Article2Headline": "'Connected around the clock': how mobile is transforming patient care",
-    "Article2URL": "https://www.theguardian.com/brother-partner-zone/2016/nov/15/connected-around-the-clock-how-mobile-is-transforming-patient-care",
+    "Article2Headline": "",
+    "Article2URL": "p/4xzbq",
     "Article2Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL8460ZxABGAEyCLHavz0J_xxG",
-    "Article2Logo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
-    "Article2LogoUrl": "http://google.com",
 
     "Article3Headline": "Can IT help the NHS deliver seven-day services?",
     "Article3URL": "https://www.theguardian.com/healthcare-network-brother-partner-zone/2015/oct/09/it-nhs-seven-day-services",
     "Article3Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846G-AEQARgBMgiltRKnG_iTTA",
-    "Article3Logo": "",
-    "Article3LogoUrl": "",
 
     "Article4Headline": "'Their body, their data': how portals can put patients in charge",
     "Article4URL": "https://www.theguardian.com/brother-partner-zone/2016/oct/27/their-body-their-data-how-portals-can-put-patients-in-charge",
-    "Article4Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846O_AEQARgBMghQVTAWK--psQ",
-    "Article4Logo": "",
-    "Article4LogoUrl": ""
+    "Article4Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846O_AEQARgBMghQVTAWK--psQ"
 }

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -4,16 +4,27 @@
     "Brand": "Unilever",
     "BrandLogo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
     "TrackingID": "1234",
-    "Article1URL": "p/52efd",
-    "Article2URL": "https://www.theguardian.com/brother-partner-zone/2016/nov/15/connected-around-the-clock-how-mobile-is-transforming-patient-care",
-    "Article3URL": "https://www.theguardian.com/healthcare-network-brother-partner-zone/2015/oct/09/it-nhs-seven-day-services",
-    "Article4URL": "https://www.theguardian.com/brother-partner-zone/2016/oct/27/their-body-their-data-how-portals-can-put-patients-in-charge",
     "Article1Headline": "It's time for the NHS to realise the benefits of digital",
-    "Article2Headline": "'Connected around the clock': how mobile is transforming patient care",
-    "Article3Headline": "Can IT help the NHS deliver seven-day services?",
-    "Article4Headline": "'Their body, their data': how portals can put patients in charge",
+    "Article1URL": "p/52efd",
     "Article1Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL8_aZahABGAEyCM7vHR3kurK0",
+    "Article1Logo": "",
+    "Article1LogoUrl": "",
+
+    "Article2Headline": "'Connected around the clock': how mobile is transforming patient care",
+    "Article2URL": "https://www.theguardian.com/brother-partner-zone/2016/nov/15/connected-around-the-clock-how-mobile-is-transforming-patient-care",
     "Article2Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL8460ZxABGAEyCLHavz0J_xxG",
+    "Article2Logo": "http://pagead2.googlesyndication.com/pagead/imgad?id=CICAgKDjnfPJbBABGAEyCHbj_OBIEKp8",
+    "Article2LogoUrl": "http://google.com",
+
+    "Article3Headline": "Can IT help the NHS deliver seven-day services?",
+    "Article3URL": "https://www.theguardian.com/healthcare-network-brother-partner-zone/2015/oct/09/it-nhs-seven-day-services",
     "Article3Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846G-AEQARgBMgiltRKnG_iTTA",
-    "Article4Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846O_AEQARgBMghQVTAWK--psQ"
+    "Article3Logo": "",
+    "Article3LogoUrl": "",
+
+    "Article4Headline": "'Their body, their data': how portals can put patients in charge",
+    "Article4URL": "https://www.theguardian.com/brother-partner-zone/2016/oct/27/their-body-their-data-how-portals-can-put-patients-in-charge",
+    "Article4Image": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDL846O_AEQARgBMghQVTAWK--psQ",
+    "Article4Logo": "",
+    "Article4LogoUrl": ""
 }

--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -26,12 +26,6 @@
     </header>
     <div class="adverts__body">
         <div class="adverts__row"></div>
-        <div class="badge js-badge">
-            Paid for by
-            <a class="badge__link" href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesURL%]" data-link-name="badge" target="_top">
-                <img class="badge__logo" src="[%BrandLogo%]" alt="">
-            </a>
-        </div>
     </div>
 </aside>
 

--- a/src/capi-multiple-paidfor/web/index.js
+++ b/src/capi-multiple-paidfor/web/index.js
@@ -1,3 +1,27 @@
 import capiMultiple from '../../_shared/js/capi-multiple.js';
+import { clickMacro } from '../../_shared/js/ads';
 
-capiMultiple("paidfor");
+const OVERRIDES = {
+    logos: ['[%Article1Logo%]', '[%Article2Logo%]', '[%Article3Logo%]', '[%Article4Logo%]'],
+    links: ['[%Article1LogoUrl%]', '[%Article2LogoUrl%]', '[%Article3LogoUrl%]', '[%Article4LogoUrl%]']
+};
+
+function buildLogo(card, cardNumber, cardInfo) {
+    let logoUrl = cardInfo.logoUrl || OVERRIDES.logos[cardNumber];
+    let brandUrl = cardInfo.brandUrl || OVERRIDES.links[cardNumber];
+
+    if( !logoUrl || !brandUrl ) return;
+
+    card.insertAdjacentHTML('beforeend', generateLogo(logoUrl, brandUrl));
+}
+
+function generateLogo(logoUrl, brandUrl) {
+    return `<div class="badge badge--branded">
+        Paid for by
+        <a class="badge__link" href="${clickMacro + brandUrl}">
+            <img class="badge__logo" src="${logoUrl}" alt>
+        </a>
+    </div>`;
+}
+
+capiMultiple("paidfor", buildLogo);

--- a/src/capi-multiple-paidfor/web/index.js
+++ b/src/capi-multiple-paidfor/web/index.js
@@ -6,13 +6,12 @@ const OVERRIDES = {
     links: ['[%Article1LogoUrl%]', '[%Article2LogoUrl%]', '[%Article3LogoUrl%]', '[%Article4LogoUrl%]']
 };
 
-function buildLogo(card, cardNumber, cardInfo) {
-    let logoUrl = cardInfo.logoUrl || OVERRIDES.logos[cardNumber];
-    let brandUrl = cardInfo.brandUrl || OVERRIDES.links[cardNumber];
+function buildLogo(card, cardNumber, cardsInfo) {
+    if( cardsInfo.isSingle ) return;
 
-    if( !logoUrl || !brandUrl ) return;
+    let cardInfo = cardsInfo.articles[cardNumber];
 
-    card.insertAdjacentHTML('beforeend', generateLogo(logoUrl, brandUrl));
+    card.insertAdjacentHTML('beforeend', generateLogo(cardInfo.branding.sponsorLogo.url, cardInfo.branding.sponsorLink));
 }
 
 function generateLogo(logoUrl, brandUrl) {


### PR DESCRIPTION
I expect AdOps to pay due diligence and not provide both a container logo and a card logo.

![picture 8](https://cloud.githubusercontent.com/assets/629976/22069310/e3f988f8-dd8f-11e6-996c-79f396821e24.jpg)
