### PR TITLE
Fix for Soulmates js

### DIFF
--- a/src/_shared/js/creatives.js
+++ b/src/_shared/js/creatives.js
@@ -1,7 +1,6 @@
 import { write } from './dom.js';
 
-export function cleanupButtons() {
-    const moreTexts = ['[%Offer1LinkText%]', '[%Offer2LinkText%]', '[%Offer3LinkText%]', '[%Offer4LinkText%]'];
+export function cleanupButtons(moreTexts) {
     const mores = Array.from(document.getElementsByClassName('advert__more'))
     .filter((more, index) => !moreTexts[index]);
 

--- a/src/manual-multiple-membership/web/index.js
+++ b/src/manual-multiple-membership/web/index.js
@@ -1,7 +1,7 @@
 import { getIframeId, getWebfonts, resizeIframeHeight, reportClicks, onViewport } from '../../_shared/js/messages.js';
 import { cleanupButtons } from '../../_shared/js/creatives.js';
 
-cleanupButtons();
+cleanupButtons(['[%Offer1LinkText%]', '[%Offer2LinkText%]', '[%Offer3LinkText%]', '[%Offer4LinkText%]']);
 
 reportClicks();
 getIframeId()

--- a/src/manual-multiple-soulmates/web/index.js
+++ b/src/manual-multiple-soulmates/web/index.js
@@ -1,7 +1,7 @@
 import { getIframeId, getWebfonts, resizeIframeHeight, reportClicks, onViewport } from '../../_shared/js/messages.js';
 import { cleanupButtons } from '../../_shared/js/creatives.js';
 
-cleanupButtons();
+cleanupButtons(['[%Offer1LinkText%]', '[%Offer2LinkText%]', '[%Offer3LinkText%]']);
 
 reportClicks();
 getIframeId()

--- a/src/manual-multiple/web/index.js
+++ b/src/manual-multiple/web/index.js
@@ -1,7 +1,7 @@
 import { getIframeId, getWebfonts, reportClicks, resizeIframeHeight, onViewport } from '../../_shared/js/messages';
 import { cleanupButtons } from '../../_shared/js/creatives';
 
-cleanupButtons();
+cleanupButtons(['[%Offer1LinkText%]', '[%Offer2LinkText%]', '[%Offer3LinkText%]', '[%Offer4LinkText%]']);
 reportClicks();
 
 getIframeId()


### PR DESCRIPTION
Pass parameters into cleanupButtons function so that the number of DFP variables can differ.

Soulmates now only has 3 cards (since https://github.com/guardian/commercial-templates/pull/125), so trying to save the new template with `[%Offer4LinkText%]` in the js didn't work.