### PR TITLE
Allow slot-injected ISBN

### DIFF
--- a/src/manual-inline-book/web/index.js
+++ b/src/manual-inline-book/web/index.js
@@ -4,9 +4,11 @@ import { getApiBaseUrl } from '../../_shared/js/dev';
 import { URLSearchParams } from '../../_shared/js/utils';
 
 let container = document.getElementsByClassName('adverts__body')[0];
+let isbn = '[%ISBN%]';
+let isbnBackup = '%%PATTERN:isbn%%';
 
 let params = new URLSearchParams();
-params.append('t', '[%ISBN%]');
+params.append('t', isbn || isbnBackup);
 
 reportClicks();
 getIframeId('inline-book')


### PR DESCRIPTION
This is because the ISBN is sometimes defined as a property of the page in composer, available as `config.page.isbn` on frontend. When available, it will be passed in as a slot targeting value.