### PR TITLE
Improve the layout of paid containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.13.3",
     "hogan.js": "^3.0.2",
     "node-sass": "^3.8.0",
+    "nodemon": "^1.11.0",
     "postcss": "^5.2.5",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/src/capi-multiple-paidfor/web/index.js
+++ b/src/capi-multiple-paidfor/web/index.js
@@ -3,7 +3,7 @@ import { clickMacro } from '../../_shared/js/ads';
 
 function generateLogo(logoUrl, brandUrl, customCSS) {
     return `<div class="badge ${customCSS || ''}">
-        Paid for by
+        <div class="badge__label">Paid for by</div>
         <a class="badge__link" href="${clickMacro + brandUrl}">
             <img class="badge__logo" src="${logoUrl}" alt>
         </a>

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -10,6 +10,43 @@
     color: $neutral-1;
 }
 
+.advert__title {
+  @include mq($until: tablet) {
+    width: 70%;
+    min-height: $gs-baseline * 5;
+  }
+}
+
+.badge {
+  @include mq($until: tablet) {
+    text-align: center;
+    margin: 0;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+}
+
+.badge__label {
+  display: inline;
+  @include mq(tablet) {
+    padding-right: $gs-gutter;
+  }
+}
+
+.badge__link {
+  display: inline;
+  @include mq($until: tablet) {
+    display: block;
+  }
+}
+
+.badge__logo {
+  @include mq($until: tablet) {
+    margin-left: 0;
+  }
+}
+
 .adverts__logo:hover {
     text-decoration: underline;
 }

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -12,7 +12,7 @@
 
 .advert__title {
   @include mq($until: tablet) {
-    width: 70%;
+    margin-right: $gs-gutter * 5;
     min-height: $gs-baseline * 5;
   }
 }
@@ -42,6 +42,7 @@
 
 .badge__logo {
   margin-left: 0;
+  max-width: $gs-gutter * 5;
 }
 
 .adverts__logo:hover {

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -18,6 +18,7 @@
 }
 
 .badge {
+  display: inline-block;
   @include mq($until: tablet) {
     text-align: center;
     margin: 0;
@@ -28,23 +29,19 @@
 }
 
 .badge__label {
-  display: inline;
-  @include mq(tablet) {
-    padding-right: $gs-gutter;
-  }
+  display: inline-block;
+  padding: 0 10px;
 }
 
 .badge__link {
-  display: inline;
+  display: inline-block;
   @include mq($until: tablet) {
     display: block;
   }
 }
 
 .badge__logo {
-  @include mq($until: tablet) {
-    margin-left: 0;
-  }
+  margin-left: 0;
 }
 
 .adverts__logo:hover {

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -20,24 +20,16 @@
 .badge {
   display: inline-block;
   @include mq($until: tablet) {
-    text-align: center;
-    margin: 0;
     position: absolute;
     bottom: 0;
     right: 0;
+    margin: 0;
   }
 }
 
 .badge__label {
   width: 100%;
   text-align: center;
-}
-
-.badge__link {
-  display: inline-block;
-  @include mq($until: tablet) {
-    display: block;
-  }
 }
 
 .badge__logo {

--- a/src/capi-multiple-paidfor/web/index.scss
+++ b/src/capi-multiple-paidfor/web/index.scss
@@ -29,8 +29,8 @@
 }
 
 .badge__label {
-  display: inline-block;
-  padding: 0 10px;
+  width: 100%;
+  text-align: center;
 }
 
 .badge__link {


### PR DESCRIPTION
- Add missing dev dependency (nodemon) so that `npm run preview` doesn't throw an error
- Better positioning of the paidFor label at all breakpoints

:grin: Making our natives match frontend: https://github.com/guardian/frontend/pull/16062
__________
### MOBILE
###### BEFORE:
<img width="324" alt="picture 571" src="https://cloud.githubusercontent.com/assets/8607683/23465632/bfcf58b4-fe90-11e6-8c70-665ee1afa05b.png">

###### AFTER:
<img width="324" alt="picture 568" src="https://cloud.githubusercontent.com/assets/8607683/23465661/d3e03daa-fe90-11e6-8d9b-3a33c7d5d68a.png">

____________

### TABLET
###### BEFORE:
<img width="766" alt="picture 572" src="https://cloud.githubusercontent.com/assets/8607683/23465746/1ce199d6-fe91-11e6-8c03-d323d2366078.png">

###### AFTER:
<img width="762" alt="picture 569" src="https://cloud.githubusercontent.com/assets/8607683/23465737/13d83f98-fe91-11e6-9947-3d86ce3995fd.png">

____________

### DESKTOP
###### BEFORE:
<img width="1248" alt="picture 570" src="https://cloud.githubusercontent.com/assets/8607683/23465845/62a2c184-fe91-11e6-850c-ee45a138b80d.png">

###### AFTER:

<img width="1144" alt="picture 626" src="https://cloud.githubusercontent.com/assets/8607683/23907712/e55f82e6-08c9-11e7-9190-06efa984aa64.png">
