### PR TITLE
Hosted container fixes

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -138,7 +138,7 @@ function buildFromCapi (host, cardsInfo, adType, generateLogo) {
 
     let cardList = document.createDocumentFragment();
 
-    cardsInfo.isSingle = cardsInfo.articles
+    cardsInfo.isSingle = adType === 'hosted' || cardsInfo.articles
         .map(cardInfo => cardInfo.branding && cardInfo.branding.logo.src)
         .reduce(((isSingle, url, index, urls) => isSingle && (index === 0 || url === urls[index - 1])), true);
 

--- a/src/_shared/js/hosted-colours.js
+++ b/src/_shared/js/hosted-colours.js
@@ -9,7 +9,7 @@ function isDark(hex) {
     let min = Math.min(R, G, B);
     let max = Math.max(R, G, B);
     let lightness = (min + max) / 510;
-    return lightness < 0.5;
+    return lightness <= 0.5;
 }
 
 export default function addColourContrastClass () {


### PR DESCRIPTION
- alter the colour contrast algorithm to be consistent with hosted pages when colour lightness === 0.5
- disable multi-logos functionality for hosted - no designs for this yet