### PR TITLE
Fix the arrow size issue on Edge 14

### DIFF
--- a/src/_shared/scss/_adverts-soulmates.scss
+++ b/src/_shared/scss/_adverts-soulmates.scss
@@ -61,8 +61,6 @@
 
         svg {
             display: inline-block;
-            width: initial;
-            height: initial;
             margin-right: $gs-gutter / 2;
             vertical-align: middle;
         }
@@ -103,6 +101,8 @@
 
     .icon--soulmates-join {
         fill: initial;
+        width: initial;
+        height: initial;
     }
 }
 


### PR DESCRIPTION
### What:

Move some CSS around  - the `width: initial; height: initial;` should only be applicable to the class `.icon--soulmates-join`, since we don't want these stlyes applied to all SVGs in the soulmates component (the arrows have reeeally large initial dimensions)

### Why:

[Commercial Trello card](https://trello.com/c/Lp72MM8T/51-soulmates-component-is-broken-in-edge-14)

Cautiously optimistic that this will fix the Microsoft Edge 14 arrow issue

### Before:

<img width="1263" alt="picture 670" src="https://cloud.githubusercontent.com/assets/8607683/24872195/7a3de16e-1e14-11e7-92d2-a15235399f63.png">


### After:

<img width="1280" alt="picture 676" src="https://cloud.githubusercontent.com/assets/8607683/24872187/6f525c08-1e14-11e7-9c60-a83906454137.png">
