### PR TITLE
Make app-specific capi-multiple-paid-for template

### DIFF
--- a/src/capi-multiple-paidfor/app/app-capi-multiple.js
+++ b/src/capi-multiple-paidfor/app/app-capi-multiple.js
@@ -1,0 +1,164 @@
+import { write } from '../../_shared/js/dom.js';
+import { enableToggles } from '../../_shared/js/ui.js';
+import { generatePicture } from '../../_shared/js/capi-images.js';
+import { clickMacro, setEditionLink } from '../../_shared/js/ads';
+import { URLSearchParams } from '../../_shared/js/utils';
+
+const ENDPOINT = 'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-multiple.json';
+
+const OVERRIDES = {
+    urls: ['[%Article1URL%]', '[%Article2URL%]', '[%Article3URL%]', '[%Article4URL%]'],
+    kickers: ['[%Article1Kicker%]', '[%Article2Kicker%]', '[%Article3Kicker%]', '[%Article4Kicker%]'],
+    headlines: ['[%Article1Headline%]', '[%Article2Headline%]', '[%Article3Headline%]', '[%Article4Headline%]'],
+    images: ['[%Article1Image%]', '[%Article2Image%]', '[%Article3Image%]', '[%Article4Image%]']
+};
+
+// Loads the card data from CAPI in JSON format.
+function retrieveCapiData () {
+    let params = new URLSearchParams();
+    params.append('k', '[%SeriesURL%]');
+    OVERRIDES.urls.forEach(url => {
+        if (url !== '') {
+            params.append('t', url);
+        }
+    });
+    return fetch(`${ENDPOINT}?${params}`)
+    .then(response => response.json());
+}
+
+// Constructs the title part of the card: headline and media icon.
+function buildTitle (card, cardInfo, cardNumber) {
+    let title = card.querySelector('.advert__title');
+    let kickerText = OVERRIDES.kickers[cardNumber];
+
+    let kicker = kickerText ? `<span class="advert__kicker">${kickerText}</span>` : '';
+    let icon = '';
+    let headline = OVERRIDES.headlines[cardNumber] || cardInfo.articleHeadline;
+
+    if (cardInfo.videoTag) {
+        card.classList.add('advert--media');
+        icon = mediaIcons['video'];
+    } else if (cardInfo.galleryTag) {
+        card.classList.add('advert--media');
+        icon = mediaIcons['camera'];
+    } else if (cardInfo.audioTag) {
+        card.classList.add('advert--media');
+        icon = mediaIcons['volume'];
+    } else {
+        card.classList.add('advert--text');
+    }
+
+    card.setAttribute('data-link-name', headline);
+
+    title.insertAdjacentHTML('beforeend', [kicker, icon, headline].join(' '));
+}
+
+// Either from template, or workaround for IE (sigh).
+function importCard (adType) {
+
+    let cardTemplate = document.getElementById(`${adType}-card`);
+
+    // Modern browsers.
+    if (cardTemplate.content) {
+        return document.importNode(cardTemplate.content, true);
+    } else {
+
+        // Internet Explorer doesn't support templates.
+        let cardFragment = document.createDocumentFragment();
+        let tempDiv = document.createElement('div');
+
+        tempDiv.innerHTML = cardTemplate.innerHTML;
+        while (tempDiv.firstChild) cardFragment.appendChild(tempDiv.firstChild);
+        return cardFragment;
+
+    }
+
+}
+
+function buildLogo(card, cardNumber, cardsInfo, generateLogo) {
+    if (cardsInfo.isSingle) return;
+
+    let cardInfo = cardsInfo.articles[cardNumber];
+    if(cardInfo.branding){
+        let logo = generateLogo(cardInfo.branding.logo.src, cardInfo.branding.logo.link, 'badge--branded');
+        card.insertAdjacentHTML('beforeend', logo);
+    }
+}
+
+// Constructs an individual card.
+function buildCard (cardInfo, cardNum, adType, cardsInfo, generateLogo) {
+
+    let cardFragment = importCard(adType);
+    let card = cardFragment.querySelector(`.advert--${adType}`);
+    let imgContainer = card.querySelector('.advert__image-container');
+
+    buildTitle(card, cardInfo, cardNum);
+    buildLogo(card, cardNum, cardsInfo, generateLogo);
+    card.href = clickMacro + cardInfo.articleUrl;
+
+    let image = generatePicture({
+        url: OVERRIDES.images[cardNum] || cardInfo.articleImage.backupSrc,
+        classes: ['advert__image'],
+        sources: !OVERRIDES.images[cardNum] && cardInfo.articleImage.sources
+    });
+
+    imgContainer.insertAdjacentHTML('afterbegin', image);
+
+    if (cardNum > 0 && adType !== "hosted") {
+        imgContainer.classList.add('hide-until-tablet');
+    }
+
+    return cardFragment;
+
+}
+
+// Adds branding information from cAPI.
+function addBranding (brandingCard, generateLogo) {
+
+    let body = document.querySelector('.js-logo-container');
+    let logoUrl = brandingCard.branding && brandingCard.branding.logo.src;
+    let sponsorLink = brandingCard.branding && brandingCard.branding.logo.link;
+
+    body.insertAdjacentHTML('beforeend', generateLogo(logoUrl, sponsorLink));
+}
+
+// Sets correct glabs link based on edition (AU/All others).
+function editionLink (host, edition, adType) {
+
+    if (adType === "paidfor") {
+        setEditionLink(host, edition, document.querySelector('.adverts__stamp a'));
+    }
+
+}
+
+// Uses cAPI data to build the ad content.
+function buildFromCapi (host, cardsInfo, adType, generateLogo) {
+
+    let cardList = document.createDocumentFragment();
+
+    cardsInfo.isSingle = adType === 'hosted' || cardsInfo.articles
+        .map(cardInfo => cardInfo.branding && cardInfo.branding.logo.src)
+        .reduce(((isSingle, url, index, urls) => isSingle && (index === 0 || url === urls[index - 1])), true);
+
+    // Constructs an array of cards from an array of data.
+    cardsInfo.articles.forEach((info, idx) => {
+        cardList.appendChild(buildCard(info, idx, adType, cardsInfo, generateLogo));
+    });
+
+    return write(() => {
+        // Takes branding from last possible card, in case earlier ones overridden.
+        let brandingCard = cardsInfo.articles.slice(-1)[0];
+        if( cardsInfo.isSingle ) {
+            addBranding(brandingCard, generateLogo);
+        }
+        let advertRow = document.querySelector('.adverts__row');
+        advertRow.appendChild(cardList);
+        editionLink(host, cardsInfo.articles[0].edition, adType);
+    });
+}
+
+export default function capiMultiple (adType, generateLogo) {
+    enableToggles();
+    retrieveCapiData()
+        .then(capiData => buildFromCapi("www.theguardian.com", capiData, adType, generateLogo));
+}

--- a/src/capi-multiple-paidfor/app/index.html
+++ b/src/capi-multiple-paidfor/app/index.html
@@ -1,0 +1,45 @@
+<aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
+    <header class="adverts__header">
+        <div class="adverts__kicker">
+            <div class="paidfor-meta">
+                <span class="paidfor-meta__label">Paid content</span>
+                <div class="paidfor-label paidfor-meta__more has-popup">
+                    <button class="u-button-reset paidfor-label__btn popup__toggle js-toggle" aria-controls="popup" aria-expanded="false" data-toggle="js-paidfor-popup">About {{#svg}}arrow-down{{/svg}}
+                    </button>
+                    <div id="popup" class="popup popup--paidfor js-paidfor-popup">
+                        <p class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</p>
+                        <a class="blink popup--paidfor__link" href="%%CLICK_URL_UNESC%%https://theguardian.com/content-funding" target="_top">Learn more about Guardian Labs content {{#svg}}arrow-right{{/svg}}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <h1 class="adverts__title">
+            <a href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesURL%]" class="blink adverts__logo u-text-hyphenate" data-link-name="header" target="_top">[%ComponentTitle%]</a>
+        </h1>
+        <div class="adverts__stamp">
+            <a href="" class="blink" data-link-name="glabs" target="_top">
+                {{#svg}}glabs-logo{{/svg}}
+                <span class='u-h blink__anchor'>Guardian Labs</span>
+            </a>
+        </div>
+    </header>
+    <div class="adverts__body js-logo-container">
+        <div class="adverts__row"></div>
+    </div>
+</aside>
+
+<template id="paidfor-card">
+    <a class="blink advert advert--capi advert--paidfor" href="" data-link-name="" target="_top">
+        <h2 class="advert__title"></h2>
+        <div class="advert__image-container"></div>
+    </a>
+</template>
+
+<script>
+var mediaIcons = {
+    camera: '{{#svg}}image{{/svg}}',
+    video: '{{#svg}}video{{/svg}}',
+    volume: '{{#svg}}audio{{/svg}}'
+};
+</script>

--- a/src/capi-multiple-paidfor/app/index.js
+++ b/src/capi-multiple-paidfor/app/index.js
@@ -1,0 +1,13 @@
+import capiMultiple from './app-capi-multiple.js';
+import { clickMacro } from '../../_shared/js/ads';
+
+function generateLogo(logoUrl, brandUrl, customCSS) {
+    return `<div class="badge ${customCSS || ''}">
+        <div class="badge__label">Paid for by</div>
+        <a class="badge__link" href="${clickMacro + brandUrl}">
+            <img class="badge__logo" src="${logoUrl}" alt>
+        </a>
+    </div>`;
+}
+
+capiMultiple("paidfor", generateLogo);

--- a/src/capi-multiple-paidfor/app/index.scss
+++ b/src/capi-multiple-paidfor/app/index.scss
@@ -1,0 +1,49 @@
+@import '_core';
+@import '_adverts';
+@import '_advert';
+@import '_adverts-capi';
+@import '_paidfor-meta';
+@import '_palette';
+@import '_popup-paidfor';
+
+.adverts {
+    color: $neutral-1;
+}
+
+.advert__title {
+  @include mq($until: tablet) {
+    flex: 1 0 50%;
+  }
+}
+
+.badge {
+  display: inline-block;
+}
+
+.badge__label {
+  width: 100%;
+  text-align: center;
+}
+
+.badge__logo {
+  margin-left: 0;
+  max-width: $gs-gutter * 5;
+}
+
+.adverts__logo:hover {
+    text-decoration: underline;
+}
+
+.icon--glabs-logo {
+    width: 75px;
+    max-height: 31px;
+}
+
+.adverts__stamp {
+    @include mq($until: tablet) {
+        position: absolute;
+        right: $gs-gutter / 2;
+        top: $gs-baseline / 2;
+    }
+
+}


### PR DESCRIPTION
This is very similar to the web capi-multiple-paid-for template, but without waiting to get the iframe ID.  I've tested it on iOS.