### PR TITLE
Amend logo to be non-absolute

### DIFF
--- a/src/google/web/index.scss
+++ b/src/google/web/index.scss
@@ -1,8 +1,6 @@
 /*
 
-Beware lots of CSS properties are disallowed here,
-
-meaning we have to use absolute positioning for the logo.
+Beware lots of CSS properties are disallowed here
 
 Change the 'width' value in the DFP preview to 300px for best results.
 
@@ -90,8 +88,10 @@ img {
 }
 
 .logo {
-    position: absolute;
-    right: 6px;
+    position: block;
+    float: right;
+    margin-right: 6px;
+    margin-top: 6px;
     bottom: 43px;
     width: 70px;
     @media ( max-height: 285px ){


### PR DESCRIPTION
By moving the logo element directly below the image in DFP we can then float it right in line with the headlines and achieve our desired design instead of using absolute positioning. Winner!

In DFP - https://www.google.com/dfp/59666047?gsessionid=ptJVasseHTklzLwxNqEovknfodaYmNxq#delivery/CreateNativeAdFormatAndStyle/nativeStyleId=109638&creativeTemplateId=10004520 