### PR TITLE
Add guardian.com to CAPI multiple-supported by template.

### DIFF
--- a/src/capi-multiple-supported/web/index.html
+++ b/src/capi-multiple-supported/web/index.html
@@ -1,7 +1,7 @@
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">
-            <a href="%%CLICK_URL_UNESC%%[%SeriesURL%]" class="blink adverts__logo u-text-hyphenate" data-link-name="header" target="_top">[%ComponentTitle%]</a>
+            <a href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesURL%]" class="blink adverts__logo u-text-hyphenate" data-link-name="header" target="_top">[%ComponentTitle%]</a>
         </h1>
     </header>
     <div class="adverts__body js-logo-container">


### PR DESCRIPTION
This fixes the clickthrough link for the CAPI multiple-supported by template.