### PR TITLE
Fix the widths of glabs-inline images; it makes everything simple.

### DIFF
--- a/src/_shared/scss/_core.scss
+++ b/src/_shared/scss/_core.scss
@@ -28,7 +28,11 @@ $mq-breakpoints: (
 
     // Tweakpoints
     desktopAd: 810px,
-    mobileLandscape: 480px
+    mobileLandscape: 480px,
+
+    // article breakpoints: the width available to an iframe in an article
+    articleMobile: 300px,
+    articleTablet: 620px
 );
 
 $creative-max-width: 1920px;

--- a/src/glabs-inline/test.json
+++ b/src/glabs-inline/test.json
@@ -1,6 +1,6 @@
 {
   "Title": "Cornwall for families: whoopers and witches, wizards and kings",
-  "ThumbnailUrl": "https://i.guim.co.uk/img/media/40b52c3b6852a4319cbbd2a917d3c03328a605da/0_1671_3367_2020/master/3367.jpg?w=620&q=20&auto=format&usm=12&fit=max&dpr=2&s=39d19e83cc26d39c449c3f8f814c0508",
+  "ThumbnailUrl": "https://i.guim.co.uk/img/media/43f3ab5089140ff4c97f9ca88c31f68b8c253cb7/0_0_6720_4032/master/6720.jpg?w=620&q=55&auto=format&usm=12&fit=max&s=610b9e195b6d62a775e76ab61acfa6ad",
   "ClickthroughUrl": "https://airbnb.co.uk",
   "Standfirst": "Cornwall is a storybook county - what better place to find your next family adventure?",
   "LogoUrl": "https://seeklogo.com/images/A/airbnb-logo-7F4086530F-seeklogo.com.png"

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -52,7 +52,6 @@ h1, p {
   font-size: 10px;
   font-weight: bold;
   color: $neutral-1;
-  margin-bottom: auto;
 
   @include mq(articleTablet) {
     font-size: 12px;
@@ -63,7 +62,7 @@ h1, p {
   display: none;
   font-size: 10px;
   color: $neutral-1;
-  margin-top: 2px;
+  margin-top: 5px;
 
   @include mq(articleTablet) {
     display: block;
@@ -74,7 +73,7 @@ h1, p {
 .body__tagline {
   font-size: 10px;
   color: $neutral-2;
-  margin-top: 4px;
+  margin-top: auto;
   margin-left: auto;
   text-align: right;
 }

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -11,7 +11,7 @@ h1, p {
 .container {
   font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
   background-color: $neutral-8;
-  border-top: 2px solid $paid-article-brand;
+  border-top: 1px solid $paid-article-brand;
   display: flex;
   flex-direction: row;
   max-width: gs-span(8);

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -15,7 +15,11 @@ h1, p {
   display: flex;
   flex-direction: row;
   max-width: gs-span(8);
-  height: 110px
+  height: 80px;
+
+  @include mq(tablet) {
+    height: 110px;
+  }
 }
 
 .margin {
@@ -32,14 +36,17 @@ h1, p {
 }
 
 .thumbnail {
-  width: 35%;
-  max-width: 184px;
-  max-height: 110px;
-  overflow:hidden;
+  width: 134px;
+  object-fit: cover;
+  height: 100%;
+
+  @include mq(tablet) {
+    width: 186px;
+  }
 }
 
 .thumbnail__img {
-  height: 100%;
+  max-height: 100%;
 }
 
 .body__title {

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -17,7 +17,7 @@ h1, p {
   max-width: gs-span(8);
   height: 80px;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     height: 110px;
   }
 }
@@ -40,7 +40,7 @@ h1, p {
   object-fit: cover;
   height: 100%;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     width: 186px;
   }
 }
@@ -55,7 +55,7 @@ h1, p {
   color: $neutral-1;
   margin-bottom: auto;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     font-size: 12px;
   }
 }
@@ -66,7 +66,7 @@ h1, p {
   color: $neutral-1;
   margin-top: 2px;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     display: block;
     font-size: 12px;
   }

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -32,7 +32,6 @@ h1, p {
   flex-basis: 0;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
 }
 
 .thumbnail {

--- a/src/glabs-left/web/index.js
+++ b/src/glabs-left/web/index.js
@@ -9,5 +9,4 @@ import { write } from '../../_shared/js/dom.js';
 reportClicks();
 
 getIframeId()
-.then(() => getWebfonts())
-.then(() => resizeIframeHeight());
+.then(() => getWebfonts());

--- a/src/glabs-left/web/index.scss
+++ b/src/glabs-left/web/index.scss
@@ -1,4 +1,5 @@
 @import '_core';
+@include mq-add-breakpoint(articleIframe, $gs-gutter * 11);
 
 a {
   text-decoration: none;
@@ -16,7 +17,7 @@ h1, p {
   flex-direction: column;
   width: $gs-gutter * 6.5;
 
-  @include mq(articleTablet) {
+  @include mq(articleIframe) {
     width: $gs-gutter * 11;
   }
 }
@@ -49,7 +50,7 @@ h1, p {
   color: $neutral-1;
   margin-bottom: 5px;
 
-  @include mq(articleTablet) {
+  @include mq(articleIframe) {
     font-size: 12px;
   }
 }
@@ -60,7 +61,7 @@ h1, p {
   font-size: 10px;
   margin-bottom: 5px;
 
-  @include mq(articleTablet) {
+  @include mq(articleIframe) {
     font-size: 12px;
     display: block;
   }
@@ -73,7 +74,7 @@ h1, p {
   margin-left: auto;
   text-align: right;
 
-  @include mq(articleTablet) {
+  @include mq(articleIframe) {
     font-size: 10px;
   }
 }

--- a/src/glabs-left/web/index.scss
+++ b/src/glabs-left/web/index.scss
@@ -12,7 +12,7 @@ h1, p {
 .container {
   font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica,Arial, 'Lucida Grande', sans-serif;
   background-color: $neutral-8;
-  border-top: 2px solid $paid-article-brand;
+  border-top: 1px solid $paid-article-brand;
   display: flex;
   flex-direction: column;
   width: $gs-gutter * 6.5;

--- a/src/glabs-left/web/index.scss
+++ b/src/glabs-left/web/index.scss
@@ -16,7 +16,7 @@ h1, p {
   flex-direction: column;
   width: $gs-gutter * 6.5;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     width: $gs-gutter * 11;
   }
 }
@@ -49,7 +49,7 @@ h1, p {
   color: $neutral-1;
   margin-bottom: 5px;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     font-size: 12px;
   }
 }
@@ -60,7 +60,7 @@ h1, p {
   font-size: 10px;
   margin-bottom: 5px;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     font-size: 12px;
     display: block;
   }
@@ -73,7 +73,7 @@ h1, p {
   margin-left: auto;
   text-align: right;
 
-  @include mq(tablet) {
+  @include mq(articleTablet) {
     font-size: 10px;
   }
 }


### PR DESCRIPTION
This PR does two things:

1. Fixes the width of the images at different breakpoints. Trying to make the image resize as the breakpoints change is a nightmare, especially considering differently proportioned images.

2. Adds `mq` breakpoint mappings that represent the width of the iframe at those breakpoints when in an article. When using media queries within an iframe, it is the size of the iframe that is queried, not the size of the device.