### PR TITLE
GLabs Traffic Driver Style updates

### DIFF
--- a/src/_shared/scss/_core.scss
+++ b/src/_shared/scss/_core.scss
@@ -90,6 +90,25 @@ $creative-max-width: 1920px;
     }
 }
 
+a.u-faux-block-link__overlay {
+  position: absolute;
+  z-index: 0;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  text-indent: 200%;
+  white-space: nowrap;
+  background: rgba(0, 0, 0, 0);
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
+}
+
 .button {
     border: 0;
     border-radius: 1000px;

--- a/src/glabs-inline/web/index.html
+++ b/src/glabs-inline/web/index.html
@@ -1,15 +1,12 @@
 <aside class="container" aria-label="inline advertisement">
   <div class="thumbnail">
-    <a href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-      <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">
-    </a>
+    <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">
   </div>
   <div class="body margin">
-    <a class="body__title" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-      <h1>[%Title%]</h1>
-    </a>
+    <h1 class="body__title">[%Title%]</h1>
     <p class="body__standfirst">[%Standfirst%]</p>
     <p class="body__tagline">Paid for by
       <img class="logo__img" src="[%LogoUrl%]" arai-hidden="true"></p>
   </div>
+  <a class="u-faux-block-link__overlay" href="%%CLICK_URL_UNESC%%%%DEST_URL%%"></a>
 </aside>

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -68,6 +68,7 @@ h1, p {
   font-size: 10px;
   color: $neutral-1;
   margin-top: 5px;
+  line-height: 1.2;
 
   @include mq(articleTablet) {
     display: block;

--- a/src/glabs-inline/web/index.scss
+++ b/src/glabs-inline/web/index.scss
@@ -2,6 +2,7 @@
 
 a {
   text-decoration: none;
+  cursor: pointer;
 }
 
 h1, p {
@@ -16,6 +17,10 @@ h1, p {
   flex-direction: row;
   max-width: gs-span(8);
   height: 80px;
+
+  &:hover {
+    background: darken($neutral-8, 7%);
+  }
 
   @include mq(articleTablet) {
     height: 110px;
@@ -49,12 +54,12 @@ h1, p {
 }
 
 .body__title {
-  font-size: 10px;
+  font-size: 14px;
   font-weight: bold;
   color: $neutral-1;
 
   @include mq(articleTablet) {
-    font-size: 12px;
+    font-size: 16px;
   }
 }
 

--- a/src/glabs-left/web/index.html
+++ b/src/glabs-left/web/index.html
@@ -1,15 +1,12 @@
 <aside class="container" aria-label="inline advertisement">
   <div class="thumbnail">
-    <a href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-      <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">
-    </a>
+    <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">
   </div>
   <div class="body margin">
-    <a class="body__title" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
-      <h1>[%Title%]</h1>
-    </a>
+    <h1 class="body__title">[%Title%]</h1>
     <p class="body__standfirst">[%Standfirst%]</p>
     <p class="body__tagline">Paid for by
       <img class="logo__img" src="[%LogoUrl%]" aria-hidden="true"></p>
   </div>
+  <a class="u-faux-block-link__overlay" href="%%CLICK_URL_UNESC%%%%DEST_URL%%"></a>
 </aside>

--- a/src/glabs-left/web/index.js
+++ b/src/glabs-left/web/index.js
@@ -9,4 +9,5 @@ import { write } from '../../_shared/js/dom.js';
 reportClicks();
 
 getIframeId()
-.then(() => getWebfonts());
+.then(() => getWebfonts())
+.then(() => resizeIframeHeight());

--- a/src/glabs-left/web/index.scss
+++ b/src/glabs-left/web/index.scss
@@ -65,6 +65,7 @@ h1, p {
   color: $neutral-1;
   font-size: 10px;
   margin-bottom: 5px;
+  line-height: 1.2;
 
   @include mq(articleIframe) {
     font-size: 12px;

--- a/src/glabs-left/web/index.scss
+++ b/src/glabs-left/web/index.scss
@@ -3,6 +3,7 @@
 
 a {
   text-decoration: none;
+  cursor: pointer;
 }
 
 h1, p {
@@ -16,6 +17,10 @@ h1, p {
   display: flex;
   flex-direction: column;
   width: $gs-gutter * 6.5;
+
+  &:hover {
+    background: darken($neutral-8, 7%);
+  }
 
   @include mq(articleIframe) {
     width: $gs-gutter * 11;
@@ -45,13 +50,13 @@ h1, p {
 }
 
 .body__title {
-  font-size: 10px;
+  font-size: 14px;
   font-weight: bold;
   color: $neutral-1;
   margin-bottom: 5px;
 
   @include mq(articleIframe) {
-    font-size: 12px;
+    font-size: 16px;
   }
 }
 


### PR DESCRIPTION
These are the final* changes to this before the test is run. They are:

1. Using a single anchor tag that overlays the entire container rather than linking individual component elements.
2. Add darken on hover, to match behaviour of inserts on frontend e.g. rich-links as well as cursor style.
3. The iframe for the glabs-left style will resize itself again. I this was removed whilst debugging a different styling issue.

*assuming we don't get drastic level of complaints about something or other.