### PR TITLE
Create a new template for wrapping around third-party creatives.

### DIFF
--- a/preview/src/js/components/Preview.js
+++ b/preview/src/js/components/Preview.js
@@ -11,7 +11,7 @@ module.exports = React.createClass({
         const src = '/template/' + this.props.selectedTemplate;
 
         return (
-            <iframe ref="iframe" className="preview-template" src={src}></iframe>
+            <iframe ref="iframe" id="test" className="preview-template" src={src}></iframe>
         );
     }
 });

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -108,6 +108,10 @@ function resizeIframeHeight(height = -1) {
         sendMessage('resize', { height });
 }
 
+function showAdvertLabel() {
+  return sendMessage('advert-label')
+}
+
 function isDocumentLoaded() {
     return document.readyState === 'complete' ?
         Promise.resolve() :
@@ -189,5 +193,6 @@ export {
     resizeIframeHeight,
     onScroll,
     onViewport,
-    reportClicks
+    reportClicks,
+    showAdvertLabel,
 };

--- a/src/fabric-custom/test.json
+++ b/src/fabric-custom/test.json
@@ -1,0 +1,5 @@
+{
+  "ShowLabel": "true",
+  "DapAssetsFolder": "test-creative",
+  "ThirdPartyTag": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrtKGjoAEQARgBMgjYagW3ARF6Fw"
+}

--- a/src/fabric-custom/web/index.html
+++ b/src/fabric-custom/web/index.html
@@ -1,0 +1,3 @@
+  <a id="js-fabric-custom" class="blink gs-container creative__link"
+      href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+  </a>

--- a/src/fabric-custom/web/index.js
+++ b/src/fabric-custom/web/index.js
@@ -1,0 +1,58 @@
+//@flow
+import { getIframeId, resizeIframeHeight, getWebfonts, showAdvertLabel } from '../../_shared/js/messages';
+import { write } from '../../_shared/js/dom';
+
+const DapAssetsRoot = `https://s3-eu-west-1.amazonaws.com/adops-assets/dap-fabrics`;
+const DapAssetsFolder = '[%DapAssetsFolder%]';
+
+const DapAssetsPath = `${DapAssetsRoot}/${DapAssetsFolder}`;
+const ThirdPartyTag = '[%ThirdPartyTag%]';
+
+const ifThenPromise = (parameter, action) => {
+  if (parameter === 'true') {
+    return action();
+  } else {
+    return Promise.resolve();
+  }
+}
+
+const fetchTag = (tagUrl: string) => {
+  return fetch(tagUrl)
+    .then(response => response.text())
+}
+
+const replaceAssetLinks = (html: string) => {
+  const re = /url\('\.\/(.*)'\)/g;
+  return html.replace(re, `url('${DapAssetsPath}/$1')`);
+}
+
+const generateTag = () => {
+  if (DapAssetsFolder) {
+    return fetchTag(`${DapAssetsPath}/index.html`)
+      .then(replaceAssetLinks)
+  } else if (ThirdPartyTag) {
+      return fetchTag(`[%ThirdPartyTag%]`)
+  }
+};
+
+const insertTag = (tag) => {
+  const placeholder = document.getElementById('js-fabric-custom');
+  const range = document.createRange();
+  range.setStart(placeholder, 0);
+  range.setEnd(placeholder, 0);
+  placeholder.appendChild(range.createContextualFragment(tag));
+};
+
+const addAdvertLabel = () => {
+  const label = `<div class="ad-slot__label">Advertisement</div>`;
+  write( () => document.body.insertAdjacentHTML('afterbegin', label));
+}
+
+const shouldShowLabel = '[%ShowLabel%]' === 'true';
+
+getIframeId()
+.then(() => shouldShowLabel ? addAdvertLabel() : Promise.resolve())
+.then(() => getWebfonts())
+.then(() => generateTag())
+.then(tag => insertTag(tag))
+.then(() => resizeIframeHeight());

--- a/src/fabric-custom/web/index.scss
+++ b/src/fabric-custom/web/index.scss
@@ -1,0 +1,17 @@
+.ad-slot__label {
+    max-width: 1300px;
+    font-size: .75rem;
+    line-height: 1.25rem;
+    position: relative;
+    height: 1.5rem;
+    background-color: #f6f6f6;
+    margin: 0 auto;
+    padding: 0 .5rem;
+    border-top: .0625rem solid #dfdfdf;
+    color: #6e6e6e;
+    text-align: left;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+}

--- a/src/fabric-custom/web/index.scss
+++ b/src/fabric-custom/web/index.scss
@@ -10,8 +10,6 @@
     border-top: .0625rem solid #dfdfdf;
     color: #6e6e6e;
     text-align: left;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
     font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 }


### PR DESCRIPTION
A new Native style that wraps a third party script in order to provide the following behaviour:
- Provides the Guardian web fonts to the iframe
- Adds the Advertisement label
- Resizes the iframe once it is done.

It achieves this by either fetching and inserting a third party tag or by fetching the assets from a specified S3 bucket and adding the `index.html` fragment into the page.

@guardian/commercial-dev 