### PR TITLE
Do not evaluate constant expressions during uglify

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -30,7 +30,11 @@ function buildJs(src, { minify, mode }) {
             `,
             outro: '}'
         }).code;
-        return minify ? uglify.minify(code, { fromString: true }).code : code;
+        return minify ? uglify.minify(code, { 
+            fromString: true,
+            compress: {
+                evaluate: false // Do not compress constant string evaluations. These often have macros.
+            } }).code : code;
     });
 }
 


### PR DESCRIPTION
According to these [options]( https://github.com/mishoo/UglifyJS2#compress-options), we can disable constant expression evaluation, things like:

```
'[%ShowLabel%]' === 'true'
```

We want uglify to ignore this, because the macro will be expanded much later, inside DFP.