### PR TITLE
Add new template for capi-multiple supported

### DIFF
--- a/src/capi-multiple-nologos/test.json
+++ b/src/capi-multiple-nologos/test.json
@@ -1,0 +1,22 @@
+{
+	"ComponentTitle": "Global Health",
+	"SeriesURL": "global-development-professionals-network/global-health-innovation",
+	"Brand": "Vulcan",
+	"TrackingID": "1234",
+	"Article1URL": "p/5bv6y",
+	"Article2URL": "",
+	"Article3URL": "",
+	"Article4URL": "",
+	"Article1Headline": "",
+	"Article2Headline": "",
+	"Article3Headline": "",
+	"Article4Headline": "",
+	"Article1Kicker": "",
+	"Article2Kicker": "Tuberculosis",
+	"Article3Kicker": "Gallery",
+	"Article4Kicker": "",
+	"Article1Image": "",
+	"Article2Image": "https://i.guim.co.uk/img/media/cd2e5a1e677013b11bced3d7cbac2edca480420a/0_254_4172_2503/master/4172.jpg?w=620&q=55&auto=format&usm=12&fit=max&s=5793ea44694d0d53a3516bbeb78c1eb3",
+	"Article3Image": "",
+	"Article4Image": ""
+}

--- a/src/capi-multiple-nologos/web/index.html
+++ b/src/capi-multiple-nologos/web/index.html
@@ -1,0 +1,25 @@
+<aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
+    <header class="adverts__header">
+        <h1 class="adverts__title">
+            <a href="%%CLICK_URL_UNESC%%https://theguardian.com/[%SeriesURL%]" class="blink adverts__logo u-text-hyphenate" data-link-name="header" target="_top">[%ComponentTitle%]</a>
+        </h1>
+    </header>
+    <div class="adverts__body js-logo-container">
+        <div class="adverts__row"></div>
+    </div>
+</aside>
+
+<template id="supported-card">
+    <a class="blink advert advert--capi advert--supported" href="" data-link-name="" target="_top">
+        <h2 class="advert__title"></h2>
+        <div class="advert__image-container"></div>
+    </a>
+</template>
+
+<script>
+    var mediaIcons = {
+        camera: '{{#svg}}image{{/svg}}',
+        video: '{{#svg}}video{{/svg}}',
+        volume: '{{#svg}}audio{{/svg}}'
+    };
+</script>

--- a/src/capi-multiple-nologos/web/index.js
+++ b/src/capi-multiple-nologos/web/index.js
@@ -1,0 +1,15 @@
+import capiMultiple from '../../_shared/js/capi-multiple.js';
+import { clickMacro } from '../../_shared/js/ads';
+
+
+function generateLogo(logoUrl, brandUrl, customCSS) {
+    return `<div class="badge ${customCSS || ''}">
+            Supported by
+            <a class="badge__link" href="${clickMacro}https://theguardian.com/[%SeriesURL%]" data-link-name="badge" target="_top">
+                <img class="badge__logo" src="${logoUrl}" alt="">
+            </a>
+            <a href="%%CLICK_URL_UNESC%%https://www.theguardian.com/sponsored-content" class="blink badge__help" data-link-name="about" target="_top">About this content</a>
+        </div>`
+}
+
+capiMultiple("supported", generateLogo);

--- a/src/capi-multiple-nologos/web/index.scss
+++ b/src/capi-multiple-nologos/web/index.scss
@@ -1,0 +1,19 @@
+@import '_core';
+@import '_adverts';
+@import '_adverts-capi';
+@import '_advert';
+@import '_brandbadge';
+@import '_palette';
+
+.adverts {
+    color: $neutral-1;
+}
+
+.badge {
+  display: none;
+}
+
+.badge__help:hover,
+.adverts__logo:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
- New template for testing b2b article promotion
- Multiple articles 'supported by' different clients, without multiple logos