### PR TITLE
Fix resizing in mobile revealer template

### DIFF
--- a/src/mobile-revealer/web/index.js
+++ b/src/mobile-revealer/web/index.js
@@ -1,5 +1,4 @@
 import { getIframeId, sendMessage, onViewport, resizeIframeHeight } from '../../_shared/js/messages.js';
-import { once } from '../../_shared/js/utils';
 
 const updateBackground = ({ height }) => {
     const [ scrollType,
@@ -33,7 +32,7 @@ const updateBackground = ({ height }) => {
 };
 
 getIframeId()
-.then(resizeIframeHeight)
+.then(() => resizeIframeHeight())
 .then(() => {
-    onViewport(once(updateBackground));
+    onViewport(updateBackground);
 });


### PR DESCRIPTION
This PR achieves two things:

1) Fixes a bug where the returned values from `getIframeId` were being passed into `resizeIframeHeight`, resulting in weird behaviour.

2) Removes `once` from the background update, given that `frontend` now supports refreshing a background image when the viewport changes.