### PR TITLE
Fabrics: always set the background colour, if provided.

### DIFF
--- a/src/fabric-expandable/web/index.js
+++ b/src/fabric-expandable/web/index.js
@@ -23,11 +23,14 @@ function handleBackground() {
         ['[%MobileBackgroundImage%]', '[%MobileBackgroundImagePosition%]', '[%MobileBackgroundImageRepeat%]', document.getElementById('linkMobile')] :
         ['[%BackgroundImage%]', '[%BackgroundImagePosition%]', '[%BackgroundImageRepeat%]', document.getElementById('linkDesktop')];
 
+    if (backgroundColour) {
+        document.documentElement.style.backgroundColor = backgroundColour;
+    }
+
     if( !backgroundImage ) return;
 
     if( scrollType === 'none' ) {
         write(() => {
-            document.documentElement.style.backgroundColor = backgroundColour;
             Object.assign(creativeLink.style, {
                 backgroundImage: `url('${backgroundImage}')`,
                 backgroundPosition,

--- a/src/fabric/web/index.js
+++ b/src/fabric/web/index.js
@@ -16,7 +16,6 @@ getIframeId()
 
     let isMobile = window.matchMedia('(max-width: 739px)').matches;
     let isTablet = window.matchMedia('(min-width: 740px) and (max-width: 979px)').matches;
-
     handleBackground(isMobile, isTablet);
 
     if( !isMobile && layer2.classList.contains('creative__layer2--animation-enabled') ) {
@@ -34,11 +33,13 @@ function handleBackground(isMobile, isTablet) {
         ['[%MobileBackgroundImage%]', '[%MobileBackgroundImagePosition%]', '[%MobileBackgroundImageRepeat%]', document.getElementById('linkMobile')] :
         ['[%BackgroundImage%]', '[%BackgroundImagePosition%]', '[%BackgroundImageRepeat%]', document.getElementById('linkDesktop')];
 
-    if( !backgroundImage ) return;
+    if (backgroundColour) {
+      document.documentElement.style.backgroundColor = backgroundColour;
+    }
 
+    if( !backgroundImage ) return;
     if( scrollType === 'none' ) {
         write(() => {
-            document.documentElement.style.backgroundColor = backgroundColour;
             Object.assign(creativeLink.style, {
                 backgroundImage: `url('${backgroundImage}')`,
                 backgroundPosition,


### PR DESCRIPTION
At the moment, if a background image is not provided then the function returns without setting the background colour.

If a background image is not provided, but a background colour _is_ provided, then we should honour this. This PR alters the behaviour to reflect this.