### PR TITLE
Force styles to explicitly request/refuse an Advertisement label.

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -3,7 +3,7 @@ const hogan = require('hogan.js');
 
 function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } = {}) {
     const partials = {
-        svg: () => (text, render) => {
+        svg: () => text => {
             const svgName = text.trim();
             try {
 
@@ -19,8 +19,7 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } 
 
         // this is used by frontend to determine whether an advertisement label is required
         // the presence of this div will indicate that no such label should be rendered
-        labelRequired: () => (text, render) => {
-
+        labelRequired: () => text => {
           const required = text.trim().toLowerCase();
           return `<div class="js-advertisement-label-required-${required}" style="display:none;"></div>`;
         },

--- a/lib/html.js
+++ b/lib/html.js
@@ -22,7 +22,7 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } 
         labelRequired: () => (text, render) => {
 
           const required = text.trim().toLowerCase();
-          return `<div id="js-advertisement-label-required-${required}" style="display:none;"></div>`;
+          return `<div class="js-advertisement-label-required-${required}" style="display:none;"></div>`;
         },
 
         ages: (

--- a/lib/html.js
+++ b/lib/html.js
@@ -17,6 +17,12 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } 
             }
         },
 
+        // this is used by frontend to determine whether an advertisement label is required
+        // the presence of this div will indicate that no such label should be rendered
+        noLabel: () => (text, render) => {
+          return `<div id="js-advertisement-label-required-false" style="display:none;"></div>`;
+        },
+
         ages: (
             () => {
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -19,8 +19,10 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } 
 
         // this is used by frontend to determine whether an advertisement label is required
         // the presence of this div will indicate that no such label should be rendered
-        noLabel: () => (text, render) => {
-          return `<div id="js-advertisement-label-required-false" style="display:none;"></div>`;
+        labelRequired: () => (text, render) => {
+
+          const required = text.trim().toLowerCase();
+          return `<div id="js-advertisement-label-required-${required}" style="display:none;"></div>`;
         },
 
         ages: (

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -195,6 +195,4 @@ export {
     resizeIframeHeight,
     onScroll,
     onViewport,
-    reportClicks,
-    showAdvertLabel,
-};
+    reportClicks};

--- a/src/blended/web/index.html
+++ b/src/blended/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--blended adverts--tone-brands" data-link-name="creative | blended component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/blended/web/index.html
+++ b/src/blended/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--blended adverts--tone-brands" data-link-name="creative | blended component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">
@@ -12,6 +13,7 @@
         </div>
     </div>
 </aside>
+
 <script>
 var arrowRight = '{{#svg}}arrow-right{{/svg}}';
 var logoBookshop = '{{#svg}}logo-bookshop{{/svg}}';

--- a/src/books/web/index.html
+++ b/src/books/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--books adverts--tone-books" data-link-name="creative | books component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/books/web/index.html
+++ b/src/books/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--books adverts--tone-books" data-link-name="creative | books component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">
@@ -24,6 +25,7 @@
         </div>
     </div>
 </aside>
+
 <script>
 var arrowRight = '{{#svg}}arrow-right{{/svg}}';
 </script>

--- a/src/capi-multiple-hosted/web/index.html
+++ b/src/capi-multiple-hosted/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="

--- a/src/capi-multiple-hosted/web/index.html
+++ b/src/capi-multiple-hosted/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="
@@ -12,7 +13,6 @@
         </div>
     </div>
 </div>
-
 
 <template id="hosted-card">
     <a class="hosted-trafficdriver__tile advert--hosted" href="" target="_top" data-link-name="" style="

--- a/src/capi-multiple-nologos/web/index.html
+++ b/src/capi-multiple-nologos/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-multiple-nologos/web/index.html
+++ b/src/capi-multiple-nologos/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-multiple-paidfor/app/index.html
+++ b/src/capi-multiple-paidfor/app/index.html
@@ -1,3 +1,4 @@
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <div class="adverts__kicker">

--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <div class="adverts__kicker">

--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <div class="adverts__kicker">

--- a/src/capi-multiple-supported/web/index.html
+++ b/src/capi-multiple-supported/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-multiple-supported/web/index.html
+++ b/src/capi-multiple-supported/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-single-paidfor/web/index.html
+++ b/src/capi-single-paidfor/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <div class="adverts__kicker">

--- a/src/capi-single-paidfor/web/index.html
+++ b/src/capi-single-paidfor/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <div class="adverts__kicker">

--- a/src/capi-single-supported/web/index.html
+++ b/src/capi-single-supported/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/capi-single-supported/web/index.html
+++ b/src/capi-single-supported/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/carrot/web/index.html
+++ b/src/carrot/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="container" aria-label="inline advertisement">
   <div class="thumbnail">
     <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">

--- a/src/carrot/web/index.html
+++ b/src/carrot/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="container" aria-label="inline advertisement">
   <div class="thumbnail">
     <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">

--- a/src/fabric-custom/test.json
+++ b/src/fabric-custom/test.json
@@ -1,5 +1,4 @@
 {
-  "ShowLabel": "true",
   "DapAssetsFolder": "test-creative",
   "ThirdPartyTag": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrtKGjoAEQARgBMgjYagW3ARF6Fw",
   "TrackingPixel": "https://gu.com/tracking-pixel.gif",

--- a/src/fabric-custom/web/index.html
+++ b/src/fabric-custom/web/index.html
@@ -1,3 +1,4 @@
+{{#labelRequired}}true{{/labelRequired}}
 <div class="creative creative--fabric-custom">
   <a id="js-fabric-custom" class="blink gs-container creative__link"
       href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric-custom/web/index.js
+++ b/src/fabric-custom/web/index.js
@@ -1,5 +1,5 @@
 //@flow
-import { getIframeId, resizeIframeHeight, getWebfonts, showAdvertLabel } from '../../_shared/js/messages';
+import { getIframeId, resizeIframeHeight, getWebfonts } from '../../_shared/js/messages';
 import { write } from '../../_shared/js/dom';
 
 const DapAssetsRoot = `https://s3-eu-west-1.amazonaws.com/adops-assets/dap-fabrics`;
@@ -43,15 +43,7 @@ const insertTag = (tag) => {
   placeholder.appendChild(range.createContextualFragment(tag));
 };
 
-const addAdvertLabel = () => {
-  const label = `<div class="ad-slot__label">Advertisement</div>`;
-  write( () => document.body.insertAdjacentHTML('afterbegin', label));
-}
-
-const shouldShowLabel = '[%ShowLabel%]' === 'true';
-
 getIframeId()
-.then(() => shouldShowLabel ? addAdvertLabel() : Promise.resolve())
 .then(() => getWebfonts())
 .then(() => generateTag())
 .then(tag => insertTag(tag))

--- a/src/fabric-expandable/test.json
+++ b/src/fabric-expandable/test.json
@@ -1,6 +1,5 @@
 {
     "ClickthroughUrl": "http://theirworld.org/campaigns/rewritingthecode",
-    "ShowLabel": "true",
     "ScrollType": "parallax",
     "ShowMoreType": "",
     "BackgroundColour": "",

--- a/src/fabric-expandable/web/index.html
+++ b/src/fabric-expandable/web/index.html
@@ -1,8 +1,4 @@
-<div class="gs-container creative__label creative__label--[%ShowLabel%]">
-    <div class="creative__label-text">
-        Advertisement
-    </div>
-</div>
+{{#labelRequired}}true{{/labelRequired}}
 <div id="creative" class="creative creative--fabric-expandable">
     <div class="js-container gs-container hide-until-tablet show-more--[%ShowMoreType%]">
         <button class="toggle toggle--arrow js-toggle" aria-controls="linkDesktop" aria-expanded="false">{{#svg}}arrow-down{{/svg}}</button>

--- a/src/fabric-expandable/web/index.js
+++ b/src/fabric-expandable/web/index.js
@@ -2,13 +2,8 @@ import { getIframeId, sendMessage, resizeIframeHeight, reportClicks } from '../.
 import { enableToggles } from '../../_shared/js/ui';
 import { write, div } from '../../_shared/js/dom';
 
-let showLabel = '[%ShowLabel%]';
-let labelHeight = 22;
-
 getIframeId()
 .then(() => {
-    if( showLabel === 'yes' ) resizeIframeHeight();
-
     reportClicks();
     handleBackground();
     handleToggle();
@@ -53,5 +48,5 @@ function handleToggle() {
 }
 
 function onToggle(isOpen) {
-    resizeIframeHeight((isOpen ? 500 : 250) + (showLabel === 'yes' ? labelHeight : 0));
+    resizeIframeHeight(isOpen ? 500 : 250);
 }

--- a/src/fabric-video-expandable/test.json
+++ b/src/fabric-video-expandable/test.json
@@ -1,5 +1,4 @@
 {
-  "ShowLabel": "yes",
   "BackgroundColour": "#ebebeb",
   "BackgroundImage": "",
   "BackgroundPosition": "center center",

--- a/src/fabric-video-expandable/web/index.html
+++ b/src/fabric-video-expandable/web/index.html
@@ -1,8 +1,4 @@
-<div class="gs-container creative__label creative__label--[%ShowLabel%]">
-    <div class="creative__label-text">
-        Advertisement
-    </div>
-</div>
+{{#labelRequired}}true{{/labelRequired}}
 <div style="background: [%BackgroundColour%]" id="creative" class="creative creative--fabric-expandable creative--fabric-video-[%VideoOptions%]">
     <div class="creative__container hide-until-tablet show-more--[%ShowMoreType%]" style="background: url('[%BackgroundImage%]') [%BackgroundRepeat%] [%BackgroundPosition%]">
         <button class="toggle toggle--arrow js-toggle" aria-controls="video" aria-expanded="false">{{#svg}}arrow-down{{/svg}}</button>

--- a/src/fabric-video-expandable/web/index.js
+++ b/src/fabric-video-expandable/web/index.js
@@ -2,7 +2,6 @@ import { getIframeId, getWebfonts, resizeIframeHeight } from '../../_shared/js/m
 import { enableToggles } from '../../_shared/js/ui';
 import { write } from '../../_shared/js/dom';
 
-let showLabel = '[%ShowLabel%]';
 let labelHeight = 22;
 let video = document.getElementById('YTPlayer');
 let videoContainer = document.getElementById('video');
@@ -11,8 +10,6 @@ let isWide = window.matchMedia('(min-width: 1300px)').matches;
 
 getIframeId()
 .then(() => {
-    if( showLabel === 'yes' ) resizeIframeHeight();
-
     getWebfonts(['GuardianTextSansWeb']);
     handleToggle();
 });
@@ -22,7 +19,7 @@ function handleToggle() {
 }
 
 function onToggle(isOpen, toggle, target) {
-    resizeIframeHeight((isOpen ? 500 : 250) + (showLabel === 'yes' ? labelHeight : 0));
+    resizeIframeHeight(isOpen ? 500 : 250);
     setTimeout((() => {
         if (video.src.indexOf('autoplay') === -1) {
             video.src += '&amp;autoplay=1';

--- a/src/fabric-video/test.json
+++ b/src/fabric-video/test.json
@@ -1,6 +1,5 @@
 {
     "ClickthroughUrl": "http://www.armani.com/gb/giorgioarmani/women/new-normal_section",
-    "ShowLabel": "yes",
     "BackgroundColour": "transparent",
     "BackgroundImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCLn4zhRRABGAEyCNF40kFrzoD3",
     "BackgroundRepeat": "no-repeat",

--- a/src/fabric-video/web/index.html
+++ b/src/fabric-video/web/index.html
@@ -1,8 +1,4 @@
-<div class="gs-container creative__label creative__label--[%ShowLabel%]">
-    <div class="creative__label-text">
-        Advertisement
-    </div>
-</div>
+{{#labelRequired}}true{{/labelRequired}}
 <div class="creative creative--fabric-video">
     <div class="gs-container">
         <a class="creative__link blink" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric-video/web/index.js
+++ b/src/fabric-video/web/index.js
@@ -1,12 +1,8 @@
 import { getIframeId, onScroll, onViewport, resizeIframeHeight, reportClicks } from '../../_shared/js/messages';
 import { write } from '../../_shared/js/dom';
 
-let showLabel = '[%ShowLabel%]';
-
 getIframeId()
 .then(() => {
-    if( showLabel === 'yes' ) resizeIframeHeight();
-
     reportClicks();
 
     let isUpdating = false;

--- a/src/fabric/test.json
+++ b/src/fabric/test.json
@@ -3,7 +3,6 @@
   "Trackingpixel": "",
   "Researchpixel": "",
   "Viewabilitypixel": "",
-  "ShowLabel": "yes",
   "BackgroundScrollType": "fixed",
   "BackgroundColour": "transparent",
   "BackgroundImage": "",

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -1,3 +1,4 @@
+{{#labelRequired}}true{{/labelRequired}}
 <div class="creative creative--fabric">
     <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet"
         href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -1,8 +1,3 @@
-<div class="gs-container creative__label creative__label--[%ShowLabel%]">
-    <div class="creative__label-text">
-        Advertisement
-    </div>
-</div>
 <div class="creative creative--fabric">
     <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet"
         href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric/web/index.js
+++ b/src/fabric/web/index.js
@@ -1,7 +1,6 @@
 import { getIframeId, onViewport, onScroll, sendMessage, resizeIframeHeight, reportClicks } from '../../_shared/js/messages.js';
 import { write } from '../../_shared/js/dom.js';
 
-let showLabel = '[%ShowLabel%]';
 let layer2 = document.getElementById('layer2');
 
 if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
@@ -10,8 +9,6 @@ if( layer2.classList.contains('creative__layer2--animation-disabled') ) {
 
 getIframeId()
 .then(() => {
-    if( showLabel === 'yes' ) resizeIframeHeight();
-
     reportClicks();
 
     let isMobile = window.matchMedia('(max-width: 739px)').matches;

--- a/src/frame/web/index.html
+++ b/src/frame/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <div class="creative creative--frame" data-link-name="creative | frame | [%TrackingId%]">
     <div class="roundel has-popup">
         <button class="roundel__button u-button-reset js-toggle" aria-controls="popup" aria-expanded="true">Ad {{#svg}}arrow-down{{/svg}}</button>

--- a/src/frame/web/index.html
+++ b/src/frame/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <div class="creative creative--frame" data-link-name="creative | frame | [%TrackingId%]">
     <div class="roundel has-popup">
         <button class="roundel__button u-button-reset js-toggle" aria-controls="popup" aria-expanded="true">Ad {{#svg}}arrow-down{{/svg}}</button>

--- a/src/gimbap-rich-media/web/index.html
+++ b/src/gimbap-rich-media/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | gimbap richmedia | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap-rich-media/web/index.html
+++ b/src/gimbap-rich-media/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | gimbap richmedia | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap-simple/web/index.html
+++ b/src/gimbap-simple/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | ad gimbap simple | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap-simple/web/index.html
+++ b/src/gimbap-simple/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | ad gimbap simple | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap/web/index.html
+++ b/src/gimbap/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="gimbap-wrap has-flex" role="complementary" data-link-name="creative | ad multiple manual | [%OmnitureId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap/web/index.html
+++ b/src/gimbap/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="gimbap-wrap has-flex" role="complementary" data-link-name="creative | ad multiple manual | [%OmnitureId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/hosted-native-traffic-driver/web/index.html
+++ b/src/hosted-native-traffic-driver/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <div id="creative" class="creative creative--hosted-mpu" data-brand-color="[%BrandColour%]" style="background-color: [%BrandColour%];">
 
     <a href="%%CLICK_URL_UNESC%%%%DEST_URL%%" class="creative__ctu" rel="nofollow" target="_top">

--- a/src/hosted-native-traffic-driver/web/index.html
+++ b/src/hosted-native-traffic-driver/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <div id="creative" class="creative creative--hosted-mpu" data-brand-color="[%BrandColour%]" style="background-color: [%BrandColour%];">
 
     <a href="%%CLICK_URL_UNESC%%%%DEST_URL%%" class="creative__ctu" rel="nofollow" target="_top">

--- a/src/jobs/web/index.html
+++ b/src/jobs/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--jobs adverts--tone-jobs" data-link-name="creative | jobs component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/jobs/web/index.html
+++ b/src/jobs/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--jobs adverts--tone-jobs" data-link-name="creative | jobs component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-book/web/index.html
+++ b/src/manual-inline-book/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-books advert--book" data-link-name="creative | manual inline | book | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-book/web/index.html
+++ b/src/manual-inline-book/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-books advert--book" data-link-name="creative | manual inline | book | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-event/web/index.html
+++ b/src/manual-inline-event/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-lives advert--live" data-link-name="creative | manual inline | event | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-event/web/index.html
+++ b/src/manual-inline-event/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-lives advert--live" data-link-name="creative | manual inline | event | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline/web/index.html
+++ b/src/manual-inline/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual inline | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline/web/index.html
+++ b/src/manual-inline/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual inline | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-hosted/web/index.html
+++ b/src/manual-multiple-hosted/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="

--- a/src/manual-multiple-hosted/web/index.html
+++ b/src/manual-multiple-hosted/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="

--- a/src/manual-multiple-membership/web/index.html
+++ b/src/manual-multiple-membership/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--manual adverts--memberships adverts--tone-memberships" data-link-name="creative | manual multiple membership | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-membership/web/index.html
+++ b/src/manual-multiple-membership/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--manual adverts--memberships adverts--tone-memberships" data-link-name="creative | manual multiple membership | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-soulmates/web/index.html
+++ b/src/manual-multiple-soulmates/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--manual adverts--soulmates adverts--tone-soulmates" data-link-name="creative | manual multiple soulmates | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-soulmates/web/index.html
+++ b/src/manual-multiple-soulmates/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--manual adverts--soulmates adverts--tone-soulmates" data-link-name="creative | manual multiple soulmates | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--manual adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual multiple | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--manual adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual multiple | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts advert--manual adverts--legacy adverts--legacy-single adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | ad single manual | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts advert--manual adverts--legacy adverts--legacy-single adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | ad single manual | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/mobile-revealer/web/index.html
+++ b/src/mobile-revealer/web/index.html
@@ -1,8 +1,3 @@
-<div class="gs-container creative__label creative__label--text">
-    <div class="creative__label-text">
-        Advertisement
-    </div>
-</div>
 <div class="creative creative--revealer">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL_ESC%%" target="_blank">
         <img class="creative__button creative__button--[%ButtonVerticalPosition%] creative__button--[%ButtonHorizontalPosition%]" src="[%Button%]" alt>

--- a/src/mobile-revealer/web/index.html
+++ b/src/mobile-revealer/web/index.html
@@ -1,3 +1,4 @@
+{{#labelRequired}}{{/labelRequired}}
 <div class="creative creative--revealer">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL_ESC%%" target="_blank">
         <img class="creative__button creative__button--[%ButtonVerticalPosition%] creative__button--[%ButtonHorizontalPosition%]" src="[%Button%]" alt>

--- a/src/mobile-revealer/web/index.html
+++ b/src/mobile-revealer/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}{{/labelRequired}}
+{{#labelRequired}}true{{/labelRequired}}
 <div class="creative creative--revealer">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL_ESC%%" target="_blank">
         <img class="creative__button creative__button--[%ButtonVerticalPosition%] creative__button--[%ButtonHorizontalPosition%]" src="[%Button%]" alt>

--- a/src/mpu-parallax/web/index.html
+++ b/src/mpu-parallax/web/index.html
@@ -1,3 +1,4 @@
+{{#labelRequired}}true{{/labelRequired}}
 <div class="creative--mpu-parallax">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" target="_new">
         <img class="creative--mpu-parallax-image-overlay" src="[%BackgroundImageOverlay%]">

--- a/src/soulmates/web/index.html
+++ b/src/soulmates/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--soulmates adverts--tone-soulmates" data-link-name="commercial | soulmates | [%OmnitureId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/soulmates/web/index.html
+++ b/src/soulmates/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--soulmates adverts--tone-soulmates" data-link-name="commercial | soulmates | [%OmnitureId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/travel/web/index.html
+++ b/src/travel/web/index.html
@@ -1,4 +1,4 @@
-{{#noLabel}}{{/noLabel}}
+{{#labelRequired}}false{{/labelRequired}}
 <aside class="adverts adverts--legacy adverts--travels adverts--tone-travels" data-link-name="creative | travel component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/travel/web/index.html
+++ b/src/travel/web/index.html
@@ -1,3 +1,4 @@
+{{#noLabel}}{{/noLabel}}
 <aside class="adverts adverts--legacy adverts--travels adverts--tone-travels" data-link-name="creative | travel component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">


### PR DESCRIPTION
Now that https://github.com/guardian/frontend/pull/18924 has been merged, we need to update the styles here to explicitly say whether they request/refuse an Advertisement label.

This will make the logic in `frontend` a lot simpler and will mean that no creatives need to include their own Advertisement label. Huzzah.