### PR TITLE
Factor out Advertisment label decision

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -17,11 +17,13 @@ function buildHtml(fs, src, js, dst, { banner = '', footer = '', mode = 'web' } 
             }
         },
 
-        // this is used by frontend to determine whether an advertisement label is required
-        // the presence of this div will indicate that no such label should be rendered
-        labelRequired: () => text => {
-          const required = text.trim().toLowerCase();
-          return `<div class="js-advertisement-label-required-${required}" style="display:none;"></div>`;
+        advertisementLabel: () => text => {
+          return `
+          <div class="gs-container creative__label creative__label">
+              <div class="creative__label-text">
+                  Advertisement
+              </div>
+          </div>`;
         },
 
         ages: (

--- a/src/blended/web/index.html
+++ b/src/blended/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--blended adverts--tone-brands" data-link-name="creative | blended component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/books/web/index.html
+++ b/src/books/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--books adverts--tone-books" data-link-name="creative | books component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-multiple-hosted/web/index.html
+++ b/src/capi-multiple-hosted/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="

--- a/src/capi-multiple-nologos/web/index.html
+++ b/src/capi-multiple-nologos/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-multiple-paidfor/app/index.html
+++ b/src/capi-multiple-paidfor/app/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <div class="adverts__kicker">

--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <div class="adverts__kicker">

--- a/src/capi-multiple-supported/web/index.html
+++ b/src/capi-multiple-supported/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi multiple component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/capi-single-paidfor/web/index.html
+++ b/src/capi-single-paidfor/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <div class="adverts__kicker">

--- a/src/capi-single-supported/web/index.html
+++ b/src/capi-single-supported/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--legacy-single adverts--capi adverts--supported adverts--tone-supported" data-link-name="creative | capi single component | [%TrackingId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/carrot/web/index.html
+++ b/src/carrot/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="container" aria-label="inline advertisement">
   <div class="thumbnail">
     <img class="thumbnail__img" src="[%ThumbnailUrl%]" aria-hidden="true">

--- a/src/fabric-custom/web/index.html
+++ b/src/fabric-custom/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative creative--fabric-custom">
   <a id="js-fabric-custom" class="blink gs-container creative__link"
       href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric-expandable/web/index.html
+++ b/src/fabric-expandable/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div id="creative" class="creative creative--fabric-expandable">
     <div class="js-container gs-container hide-until-tablet show-more--[%ShowMoreType%]">
         <button class="toggle toggle--arrow js-toggle" aria-controls="linkDesktop" aria-expanded="false">{{#svg}}arrow-down{{/svg}}</button>

--- a/src/fabric-video-expandable/web/index.html
+++ b/src/fabric-video-expandable/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div style="background: [%BackgroundColour%]" id="creative" class="creative creative--fabric-expandable creative--fabric-video-[%VideoOptions%]">
     <div class="creative__container hide-until-tablet show-more--[%ShowMoreType%]" style="background: url('[%BackgroundImage%]') [%BackgroundRepeat%] [%BackgroundPosition%]">
         <button class="toggle toggle--arrow js-toggle" aria-controls="video" aria-expanded="false">{{#svg}}arrow-down{{/svg}}</button>

--- a/src/fabric-video/web/index.html
+++ b/src/fabric-video/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative creative--fabric-video">
     <div class="gs-container">
         <a class="creative__link blink" href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative creative--fabric">
     <a id="linkDesktop" class="blink gs-container creative__link hide-until-tablet"
         href="%%CLICK_URL_UNESC%%%%DEST_URL%%">

--- a/src/frame/web/index.html
+++ b/src/frame/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <div class="creative creative--frame" data-link-name="creative | frame | [%TrackingId%]">
     <div class="roundel has-popup">
         <button class="roundel__button u-button-reset js-toggle" aria-controls="popup" aria-expanded="true">Ad {{#svg}}arrow-down{{/svg}}</button>

--- a/src/gimbap-rich-media/web/index.html
+++ b/src/gimbap-rich-media/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | gimbap richmedia | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap-simple/web/index.html
+++ b/src/gimbap-simple/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="gimbap-wrap gimbap-wrap--tone-[%ComponentTone%]" role="complementary" data-link-name="creative | ad gimbap simple | [%TrackingId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/gimbap/web/index.html
+++ b/src/gimbap/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="gimbap-wrap has-flex" role="complementary" data-link-name="creative | ad multiple manual | [%OmnitureId%]">
     <div class="gimbap-wrap__box">
         <header class="gimbap-wrap__header">

--- a/src/hosted-native-traffic-driver/web/index.html
+++ b/src/hosted-native-traffic-driver/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <div id="creative" class="creative creative--hosted-mpu" data-brand-color="[%BrandColour%]" style="background-color: [%BrandColour%];">
 
     <a href="%%CLICK_URL_UNESC%%%%DEST_URL%%" class="creative__ctu" rel="nofollow" target="_top">

--- a/src/jobs/web/index.html
+++ b/src/jobs/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--jobs adverts--tone-jobs" data-link-name="creative | jobs component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-book/web/index.html
+++ b/src/manual-inline-book/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-books advert--book" data-link-name="creative | manual inline | book | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline-event/web/index.html
+++ b/src/manual-inline-event/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--tone-lives advert--live" data-link-name="creative | manual inline | event | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-inline/web/index.html
+++ b/src/manual-inline/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--manual adverts--legacy-inline adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual inline | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-hosted/web/index.html
+++ b/src/manual-multiple-hosted/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <div class="creative creative--hosted gs-container with-[%numberOfElements%]-elements"
      data-link-name="Hosted Thrasher Multi" data-brand-color="[%BrandColour%]">
     <div class="fc-container__inner" style="

--- a/src/manual-multiple-membership/web/index.html
+++ b/src/manual-multiple-membership/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--manual adverts--memberships adverts--tone-memberships" data-link-name="creative | manual multiple membership | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple-soulmates/web/index.html
+++ b/src/manual-multiple-soulmates/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--manual adverts--soulmates adverts--tone-soulmates" data-link-name="creative | manual multiple soulmates | [%OmnitureId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--manual adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | manual multiple | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts advert--manual adverts--legacy adverts--legacy-single adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | ad single manual | [%OmnitureId%]">
   <header class="adverts__header">
       <h1 class="adverts__title">

--- a/src/mobile-revealer/web/index.html
+++ b/src/mobile-revealer/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative creative--revealer">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL_ESC%%" target="_blank">
         <img class="creative__button creative__button--[%ButtonVerticalPosition%] creative__button--[%ButtonHorizontalPosition%]" src="[%Button%]" alt>

--- a/src/parallax-mpu/web/index.html
+++ b/src/parallax-mpu/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}true{{/labelRequired}}
+{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative--parallax-mpu">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" target="_new">
         <img class="creative--parallax-mpu-image-overlay" src="[%BackgroundImageOverlay%]">

--- a/src/soulmates/web/index.html
+++ b/src/soulmates/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--soulmates adverts--tone-soulmates" data-link-name="commercial | soulmates | [%OmnitureId%]">
   <header class="adverts__header">
     <h1 class="adverts__title">

--- a/src/travel/web/index.html
+++ b/src/travel/web/index.html
@@ -1,4 +1,4 @@
-{{#labelRequired}}false{{/labelRequired}}
+
 <aside class="adverts adverts--legacy adverts--travels adverts--tone-travels" data-link-name="creative | travel component | [%TrackingId%]">
     <header class="adverts__header">
         <h1 class="adverts__title">


### PR DESCRIPTION
### Background
This is a tail-between-legs PR that basically undoes #191. The hope of the previous PR was to allow creatives to explicitly opt in/out to having an Advertisement label, thus removing all decision making from `frontend`.

It seems obvious now but, due to these serving in safe frames, we can't inspect the creative once it has rendered into the page and getting the creative to use `PostMessage` to send a message to hide the label is too slow and results in an ugly flash of the label.

### Changes
All this PR now does is re-add in the Advertisement label for those creatives that will always require it, but leaves it as a template macro, for simplicity and consistency.