### PR TITLE
Update flex-direction for CAPI template on tablet

### DIFF
--- a/src/_shared/scss/_adverts-capi.scss
+++ b/src/_shared/scss/_adverts-capi.scss
@@ -30,9 +30,13 @@
 .adverts--paidfor {
     .adverts__header {
         position: relative;
-            flex-direction: column;
+        flex-direction: column;
     }
-
+    @include mq(tablet, desktop) {
+      .adverts__header {
+        flex-direction: row;
+      }
+    }
     @include mq(mobileLandscape, leftCol) {
         .paidfor-meta__more {
             position: relative;


### PR DESCRIPTION
Turns out when I adjusted the flex- for the CAPI template I didn't check how it looked at tablet breakpoint. Awkward.

- Added a media query to the capi CSS to change flex-direction at tablet (not desktop) breakpoint so the header div changes from:

![image](https://user-images.githubusercontent.com/4101937/37463604-a939f19e-284d-11e8-8411-6de1f5d73a0a.png)

to 

![image](https://user-images.githubusercontent.com/4101937/37464052-177daa50-284f-11e8-844d-5d4cd003dff5.png)
