### PR TITLE
Change the Fabric Custom Viewability Tracker to be a 1x1 pixel

### DIFF
--- a/src/fabric-custom/web/index.html
+++ b/src/fabric-custom/web/index.html
@@ -5,5 +5,5 @@
   </a>
   <img src="[%TrackingPixel%]%%CACHEBUSTER%%" class="creative__pixel">
   <img src="[%ResearchPixel%]%%CACHEBUSTER%%" class="creative__pixel">
-  <div id="viewabilityTracker">[%ViewabilityTracker%]</div>
+  <img src="[%ViewabilityTracker%]%%CACHEBUSTER%%" class="creative__pixel">
 <div>


### PR DESCRIPTION
Fixes a bug where the viewability tracking pixel appears on the outside of the template. 

Before
![image 2](https://user-images.githubusercontent.com/19835654/39827544-2265c9f2-53b0-11e8-924d-17aa0e51cce6.png)

After
![picture 292](https://user-images.githubusercontent.com/19835654/39827551-262312de-53b0-11e8-9ed5-159b09594b7f.png)

