### PR TITLE
Epic tweaks

### DIFF
--- a/src/epic/test.json
+++ b/src/epic/test.json
@@ -8,5 +8,6 @@
     "PaypalAndCreditCard": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCb1LS4GhABGAEyCLs5u7YA0mOt",
     "PATTERN:pv": "preview_page_view_id",
     "PATTERN:url": "http://localhost:3000/books/2017/dec/15/good-night-stories-for-rebel-girls-jk-rowling#ab-AcquisitionsEpicNativeVsDfp=dfp",
-    "PATTERN:cc": "NZ"
+    "PATTERN:cc": "NZ",
+    "CLICK_URL_UNESC": ""
 }

--- a/src/epic/web/index.html
+++ b/src/epic/web/index.html
@@ -29,7 +29,7 @@
         <div class="contributions__amount-field">    
             <div>
                 <a 
-                    class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button js-epic-single-button" href="https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22[%Source%]%22%2C%22componentId%22%3A%22[%ComponentId%]%22%2C%22componentType%22%3A%22[%ComponentType%]%22%2C%22campaignCode%22%3A%22[%CampaignCode%]%22%2C%22abTest%22%3A%7B%22name%22%3A%22[%ABTestName%]%22%2C%22variant%22%3A%22[%ABTestVariant%]%22%7D%2C%22referrerPageviewId%22%3A%22%%PATTERN:pv%%%22%7D" 
+                    class="contributions__option-button contributions__contribute contributions__contribute--epic contributions__contribute--epic-member contributions__contribute--epic-single-button js-epic-single-button" href="%%CLICK_URL_UNESC%%https://support.theguardian.com/contribute?acquisitionData=%7B%22source%22%3A%22[%Source%]%22%2C%22componentId%22%3A%22[%ComponentId%]%22%2C%22componentType%22%3A%22[%ComponentType%]%22%2C%22campaignCode%22%3A%22[%CampaignCode%]%22%2C%22abTest%22%3A%7B%22name%22%3A%22[%ABTestName%]%22%2C%22variant%22%3A%22[%ABTestVariant%]%22%7D%2C%22referrerPageviewId%22%3A%22%%PATTERN:pv%%%22%7D" 
                     target="_blank">
                 Support The Guardian
                 </a>

--- a/src/epic/web/index.scss
+++ b/src/epic/web/index.scss
@@ -101,7 +101,7 @@
     margin-top: $gs-baseline * 2;
 
     // Horizontal alignment
-    align-items: left;
+    align-items: flex-start;
 
     @include mq($from: mobileLandscape) {
         flex-direction: row;


### PR DESCRIPTION
__Changes:__

- Epic CSS fix. Change taken from [#19891](https://github.com/guardian/frontend/pull/19891).
- DFP click through macro added to support link - this allows us to track click-through rate in DFP

__Note:__

The Epic HTML and CSS files generated by `npm run build` have already been uploaded to the DFP line item `contributions/test:AcquisitionsEpicNativeVsDfpV2/variant:dfp`. Testing locally has verified the link is valid with the click-though macro.