### PR TITLE
Hide the branding labels on capi-multiple if the branding is missing 

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -17,7 +17,7 @@ const OVERRIDES = {
 
 // Loads the card data from CAPI in JSON format.
 function retrieveCapiData () {
-    let params = new URLSearchParams();
+    const params = new URLSearchParams();
     params.append('k', '[%SeriesURL%]');
     OVERRIDES.urls.forEach(url => {
         if (url !== '') {
@@ -58,7 +58,7 @@ function buildTitle (card, cardInfo, cardNumber) {
 // Either from template, or workaround for IE (sigh).
 function importCard (adType) {
 
-    let cardTemplate = document.getElementById(`${adType}-card`);
+    const cardTemplate = document.getElementById(`${adType}-card`);
 
     // Modern browsers.
     if (cardTemplate.content) {
@@ -66,22 +66,20 @@ function importCard (adType) {
     } else {
 
         // Internet Explorer doesn't support templates.
-        let cardFragment = document.createDocumentFragment();
-        let tempDiv = document.createElement('div');
+        const cardFragment = document.createDocumentFragment();
+        const tempDiv = document.createElement('div');
 
         tempDiv.innerHTML = cardTemplate.innerHTML;
         while (tempDiv.firstChild) cardFragment.appendChild(tempDiv.firstChild);
         return cardFragment;
-
     }
-
 }
 
 function buildLogo(card, cardNumber, cardsInfo, generateLogo) {
     if (cardsInfo.isSingle) return;
 
-    let cardInfo = cardsInfo.articles[cardNumber];
-    if(cardInfo.branding){
+    const cardInfo = cardsInfo.articles[cardNumber];
+    if (cardInfo.branding) {
         let logo = generateLogo(cardInfo.branding.logo.src, cardInfo.branding.logo.link, 'badge--branded');
         card.insertAdjacentHTML('beforeend', logo);
     }
@@ -90,15 +88,15 @@ function buildLogo(card, cardNumber, cardsInfo, generateLogo) {
 // Constructs an individual card.
 function buildCard (cardInfo, cardNum, adType, cardsInfo, generateLogo) {
 
-    let cardFragment = importCard(adType);
-    let card = cardFragment.querySelector(`.advert--${adType}`);
-    let imgContainer = card.querySelector('.advert__image-container');
+    const cardFragment = importCard(adType);
+    const card = cardFragment.querySelector(`.advert--${adType}`);
+    const imgContainer = card.querySelector('.advert__image-container');
 
     buildTitle(card, cardInfo, cardNum);
     buildLogo(card, cardNum, cardsInfo, generateLogo);
     card.href = clickMacro + cardInfo.articleUrl;
 
-    let image = generatePicture({
+    const image = generatePicture({
         url: OVERRIDES.images[cardNum] || cardInfo.articleImage.backupSrc,
         classes: ['advert__image'],
         sources: !OVERRIDES.images[cardNum] && cardInfo.articleImage.sources
@@ -116,12 +114,16 @@ function buildCard (cardInfo, cardNum, adType, cardsInfo, generateLogo) {
 
 // Adds branding information from cAPI.
 function addBranding (brandingCard, generateLogo) {
+    const logoContainer = document.querySelector('.js-logo-container');
+    const logoUrl = brandingCard.branding && brandingCard.branding.logo.src;
+    const sponsorLink = brandingCard.branding && brandingCard.branding.logo.link;
 
-    let body = document.querySelector('.js-logo-container');
-    let logoUrl = brandingCard.branding && brandingCard.branding.logo.src;
-    let sponsorLink = brandingCard.branding && brandingCard.branding.logo.link;
-
-    body.insertAdjacentHTML('beforeend', generateLogo(logoUrl, sponsorLink));
+    // TODO: check that there is branding information before trying to add it...
+    if (logoContainer && logoUrl) {
+      logoContainer.insertAdjacentHTML('beforeend', generateLogo(logoUrl, sponsorLink));
+    } else {
+      // TODO: fail gracefully and maybe give a nice debug message
+    }
 }
 
 // Sets correct glabs link based on edition (AU/All others).
@@ -135,8 +137,7 @@ function editionLink (host, edition, adType) {
 
 // Uses cAPI data to build the ad content.
 function buildFromCapi (host, cardsInfo, adType, generateLogo) {
-
-    let cardList = document.createDocumentFragment();
+    const cardList = document.createDocumentFragment();
 
     cardsInfo.isSingle = adType === 'hosted' || cardsInfo.articles
         .map(cardInfo => cardInfo.branding && cardInfo.branding.logo.src)

--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -118,7 +118,6 @@ function addBranding (brandingCard, generateLogo) {
     const logoUrl = brandingCard.branding && brandingCard.branding.logo.src;
     const sponsorLink = brandingCard.branding && brandingCard.branding.logo.link;
 
-    // TODO: check that there is branding information before trying to add it...
     if (logoContainer && logoUrl) {
       logoContainer.insertAdjacentHTML('beforeend', generateLogo(logoUrl, sponsorLink));
     } else {

--- a/src/capi-multiple-hosted/test.json
+++ b/src/capi-multiple-hosted/test.json
@@ -1,6 +1,6 @@
 {
-    "ComponentTitle": "mixed test",
-    "SeriesURL": "aadvertiser-content/sony-pictures-baby-driver/sony-pictures-baby-driver",
+    "ComponentTitle": "Hosted Content",
+    "SeriesURL": "advertiser-content/trailfinders-beyond-the-beach",
     "BrandColour": "#201641",
     "numberOfElements": "2",
     "TrackingID": "",

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -1,10 +1,10 @@
 {
-    "ComponentTitle": "Discover canal trust",
-    "SeriesURL": "discover-canal-river-trust/discover-canal-river-trust",
-    "Brand": "Unilever",
+    "ComponentTitle": "Barclays Lets Go Forward",
+    "SeriesURL": "barclays-lets-go-forward",
+    "Brand": "Barclays",
     "TrackingID": "",
     "Article1Headline": "",
-    "Article1Kicker": "tuberculosis",
+    "Article1Kicker": "GDPR",
     "Article1URL": "",
     "Article1Image": "",
 

--- a/src/capi-multiple-supported/test.json
+++ b/src/capi-multiple-supported/test.json
@@ -1,5 +1,5 @@
 {
-	"ComponentTitle": "Global Health",
+	"ComponentTitle": "Business Made Simple",
 	"SeriesURL": "small-business-network/series/business-made-simple",
 	"Brand": "",
 	"TrackingID": "",


### PR DESCRIPTION

### 👉  Hide the branding labels if the branding is missing

Intermediate step is solving a missing label issue. It seems that some content does not have or pass through active sponsorship data. So this PR adds a sanity check to see if there is branding to be applied, before adding the labels.

BEFORE:

<img width="1152" alt="picture 127" src="https://user-images.githubusercontent.com/8607683/42679248-32399a1a-8679-11e8-8f23-faaeb40bfb93.png">

AFTER:

<img width="1148" alt="picture 126" src="https://user-images.githubusercontent.com/8607683/42679260-3a18703a-8679-11e8-8bbf-1668974e56bb.png">

### 👉  Swap some usage of `let` for `const` where no rebinding happens

I would rather use `const` as the default anyway and avoid rebinding as much as possible

### 👉  Update the test values for capi-multiple templates

Some of the test campaigns have expired so switching to alternatives