### PR TITLE
Add pixel fields to Fabric Video and Fabric templates

### DIFF
--- a/src/fabric-video/web/index.html
+++ b/src/fabric-video/web/index.html
@@ -30,7 +30,7 @@
         </a>
     </div>
 
-    <img src="[%Trackingpixel%]" class="creative__pixel">
-    <img src="[%Researchpixel%]" class="creative__pixel">
-    <img src="[%Viewabilitypixel%]" class="creative__pixel">
+    <img src="[%Trackingpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Researchpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Viewabilitypixel%]%%CACHEBUSTER%%" class="creative__pixel">
 </div>

--- a/src/fabric-video/web/index.html
+++ b/src/fabric-video/web/index.html
@@ -30,5 +30,7 @@
         </a>
     </div>
 
-    <img src="[%Trackingpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Trackingpixel%]" class="creative__pixel">
+    <img src="[%Researchpixel%]" class="creative__pixel">
+    <img src="[%Viewabilitypixel%]" class="creative__pixel">
 </div>

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -38,5 +38,7 @@
         </div>
     </a>
 
-    <img src="[%Trackingpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Trackingpixel%]" class="creative__pixel">
+    <img src="[%Researchpixel%]" class="creative__pixel">
+    <img src="[%Viewabilitypixel%]" class="creative__pixel">
 </div>

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -38,7 +38,7 @@
         </div>
     </a>
 
-    <img src="[%Trackingpixel%]" class="creative__pixel">
-    <img src="[%Researchpixel%]" class="creative__pixel">
-    <img src="[%Viewabilitypixel%]" class="creative__pixel">
+    <img src="[%Trackingpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Researchpixel%]%%CACHEBUSTER%%" class="creative__pixel">
+    <img src="[%Viewabilitypixel%]%%CACHEBUSTER%%" class="creative__pixel">
 </div>


### PR DESCRIPTION
In the Fabric Video and Fabric templates add in a Viewability, Research and Tracking pixel. Also remove an unnecessary cachebuster that gets added in the tag itself, to avoid duplication. 