### PR TITLE
Fix broken util task by updating DFP API references

### DIFF
--- a/style-sync/build.sbt
+++ b/style-sync/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.12.3"
 val slf4jVersion = "1.7.5"
 
 libraryDependencies ++= Seq(
-  "com.google.api-ads" % "dfp-axis" % "3.7.0",
+  "com.google.api-ads" % "dfp-axis" % "4.1.0",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "org.slf4j" % "slf4j-simple" % slf4jVersion
 )

--- a/style-sync/src/main/scala/commercialtools/stylesync/DFP.scala
+++ b/style-sync/src/main/scala/commercialtools/stylesync/DFP.scala
@@ -2,10 +2,10 @@ package commercialtools.stylesync
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.dfp.axis.factory.DfpServices
-import com.google.api.ads.dfp.axis.utils.v201708.StatementBuilder
-import com.google.api.ads.dfp.axis.v201708.{CreativeTemplate, CreativeTemplateServiceInterface, NativeStyle, NativeStyleServiceInterface, NativeStyleStatus}
-import com.google.api.ads.dfp.lib.client.DfpSession
+import com.google.api.ads.admanager.axis.factory.AdManagerServices
+import com.google.api.ads.admanager.axis.utils.v201808.StatementBuilder
+import com.google.api.ads.admanager.axis.v201808.{CreativeTemplate, CreativeTemplateServiceInterface, NativeStyle, NativeStyleServiceInterface, NativeStyleStatus}
+import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.api.client.auth.oauth2.Credential
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -19,17 +19,17 @@ trait Logging {
 // this is largely based off the documentation here: https://developers.google.com/doubleclick-publishers/docs/native
 object DFP extends Logging {
   val creds: Credential = new OfflineCredentials.Builder()
-    .forApi(Api.DFP)
+    .forApi(Api.AD_MANAGER)
     .fromFile()
     .build()
     .generateCredential()
 
-  val session: DfpSession = new DfpSession.Builder()
+  val session: AdManagerSession = new AdManagerSession.Builder()
     .fromFile()
     .withOAuth2Credential(creds)
     .build()
 
-  lazy val services: DfpServices = new DfpServices()
+  lazy val services: AdManagerServices = new AdManagerServices()
 
   lazy val nativeStyleService: NativeStyleServiceInterface = services.get(session, classOf[NativeStyleServiceInterface])
 

--- a/style-sync/src/main/scala/commercialtools/stylesync/StyleSync.scala
+++ b/style-sync/src/main/scala/commercialtools/stylesync/StyleSync.scala
@@ -3,7 +3,7 @@ package commercialtools.stylesync
 import java.io.File
 import java.nio.file.Paths
 
-import com.google.api.ads.dfp.axis.v201708.{CreativeTemplate, CreativeTemplateType, NativeStyle}
+import com.google.api.ads.admanager.axis.v201808.{CreativeTemplate, CreativeTemplateType, NativeStyle}
 
 import scala.io.Source
 
@@ -69,7 +69,7 @@ object StyleSync extends App {
   case class DiffLine(line: String, number: Int)
   case class DiffResult(diffLines: List[DiffLine], sourceALines: List[String], sourceBLines: List[String])
 
-  val buildRootDirectory = new File("/Users/jon_norman/dev/commercial-templates/build")
+  val buildRootDirectory = new File("/Users/kate_whalen/Projects/commercial-templates/build")
   val divider: String = "------------------------------------------------------------------"
 
   def summarise(formats: List[CreativeTemplate], styles: List[NativeStyle], guStyles: List[GuStyle]): Unit = {


### PR DESCRIPTION
DFP is now called AdManager...

This breaks a lot of things in the API since the version on which we were relying is now sunsetted.

This change will make the StyleSync tool work once more!

Thank the fabulous @JonNorman for the fix 🙏 🙇 🎉 