### PR TITLE
Fix parallax MPU bug

### DIFF
--- a/src/carrot/web/index.scss
+++ b/src/carrot/web/index.scss
@@ -49,6 +49,7 @@ h1, p {
   font-weight: bold;
   color: $neutral-1;
   margin-bottom: 5px;
+  line-height: 1.2;
 }
 
 .body__standfirst {
@@ -78,6 +79,6 @@ h1, p {
 
 .logo__img {
   margin-left: 2px;
-  max-width: 40px;
-  max-height: 25px;
+  max-width: 80px;
+  max-height: 50px;
 }

--- a/src/parallax-mpu/web/index.html
+++ b/src/parallax-mpu/web/index.html
@@ -1,4 +1,3 @@
-{{#advertisementLabel}}{{/advertisementLabel}}
 <div class="creative--parallax-mpu">
     <a class="creative__cta" href="%%CLICK_URL_UNESC%%%%DEST_URL%%" target="_new">
         <img class="creative--parallax-mpu-image-overlay" src="[%BackgroundImageOverlay%]">

--- a/src/parallax-mpu/web/index.js
+++ b/src/parallax-mpu/web/index.js
@@ -8,16 +8,16 @@ const updateBackground = ({ height }) => {
         backgroundRepeat,
         backgroundPosition,
         backgroundSize,
-        transform ] = [
-        'fixed',
+        transform] = [
+        'parallax',
         '#f6f6f6',
         `url('[%BackgroundImage%]')`,
         'repeat-y',
         'center center',
-        'contain',
+        'cover',
         'translate3d(0,0,0)'
     ];
-    
+
     sendMessage('background', {
         scrollType,
         backgroundColour,


### PR DESCRIPTION
When updating to the latest version of Chrome, it caused the parallax functionality of the Parallax MPU native format to break. The background image was no longer visible. Changing the scroll type to parallax instead of fixed, and covering the background image instead of containing fixes the issue.  

NB: it seems a bit jerky on mobile but it's a quick fix for now for a big Google campaign going live ASAP. Mobile jerkiness will be a separate PR.