### PR TITLE
Add tracking pixel img to capi template HTML

### DIFF
--- a/src/_shared/js/capi-multiple.js
+++ b/src/_shared/js/capi-multiple.js
@@ -12,7 +12,8 @@ const OVERRIDES = {
     urls: ['[%Article1URL%]', '[%Article2URL%]', '[%Article3URL%]', '[%Article4URL%]'],
     kickers: ['[%Article1Kicker%]', '[%Article2Kicker%]', '[%Article3Kicker%]', '[%Article4Kicker%]'],
     headlines: ['[%Article1Headline%]', '[%Article2Headline%]', '[%Article3Headline%]', '[%Article4Headline%]'],
-    images: ['[%Article1Image%]', '[%Article2Image%]', '[%Article3Image%]', '[%Article4Image%]']
+    images: ['[%Article1Image%]', '[%Article2Image%]', '[%Article3Image%]', '[%Article4Image%]'],
+    articleUrl: ['[%Article1URLOverride%]', '[%Article2URLOverride%]', '[%Article3URLOverride%]', '[%Article4URLOverride%]']
 };
 
 // Loads the card data from CAPI in JSON format.
@@ -94,7 +95,7 @@ function buildCard (cardInfo, cardNum, adType, cardsInfo, generateLogo) {
 
     buildTitle(card, cardInfo, cardNum);
     buildLogo(card, cardNum, cardsInfo, generateLogo);
-    card.href = clickMacro + cardInfo.articleUrl;
+    card.href = `${clickMacro}${OVERRIDES.articleUrl[cardNum] || cardInfo.articleUrl}`;
 
     const image = generatePicture({
         url: OVERRIDES.images[cardNum] || cardInfo.articleImage.backupSrc,

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -1,10 +1,10 @@
 {
-    "ComponentTitle": "Barclays Lets Go Forward",
-    "SeriesURL": "barclays-lets-go-forward",
+    "ComponentTitle": "Sweet Veganuary",
+    "SeriesURL": "sweet-veganuary",
     "Brand": "Barclays",
     "TrackingID": "",
     "Article1Headline": "",
-    "Article1Kicker": "GDPR",
+    "Article1Kicker": "Vegans",
     "Article1URL": "",
     "Article1Image": "",
 

--- a/src/capi-multiple-paidfor/test.json
+++ b/src/capi-multiple-paidfor/test.json
@@ -1,25 +1,30 @@
 {
     "ComponentTitle": "Sweet Veganuary",
     "SeriesURL": "sweet-veganuary",
-    "Brand": "Barclays",
+    "Brand": "Ben and Jerrys",
     "TrackingID": "",
     "Article1Headline": "",
     "Article1Kicker": "Vegans",
     "Article1URL": "",
     "Article1Image": "",
+    "Article1URLOverride": "https://www.theguardian.com/",
 
     "Article2Headline": "",
     "Article2Kicker": "",
     "Article2URL": "",
     "Article2Image": "",
+    "Article2URLOverride": "",
 
     "Article3Headline": "",
     "Article3Kicker": "",
     "Article3URL": "",
     "Article3Image": "",
+    "Article3URLOverride": "",
 
     "Article4Headline": "",
     "Article4Kicker": "",
     "Article4URL": "",
-    "Article4Image": ""
+    "Article4Image": "",
+    "Article4URLOverride": "",
+    "Trackingpixel": "",
 }

--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -27,6 +27,7 @@
     </header>
     <div class="adverts__body js-logo-container">
         <div class="adverts__row"></div>
+        <img src="[%Trackingpixel%]%%CACHEBUSTER%%" class="creative__pixel">
     </div>
 </aside>
 


### PR DESCRIPTION
Adding an <img> tag with the class name creative__pixel to the bottom of the HTML in the capi-multiple template.

(also updated the test.json file with live microsite).