### PR TITLE
Update polyfill address and version

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,7 +19,7 @@ let features = [
 let options = {
     banner: `
 <base target="_blank">
-<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=${encodeURIComponent(features.join(','))}"></script>
+<script src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=${encodeURIComponent(features.join(','))}&clearCache=2"></script>
     `,
     src: 'src',
     dst: 'build',


### PR DESCRIPTION
This updates the polyfill address used within templates;
 - We now use `v3` instead of `v2`
 - Caching issues have been fixed on assets.guim.co.uk

`clearCache` has also been added; this isn't a requirement however it's good to know how to bust the cache in scenarios where we need to. (Which we have had to on polyfill!)