### PR TITLE
Add custom message to handle empty source files.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,12 +1,17 @@
 {
-    "ignoreFiles": ["node_modules/**/*.s+(a|c)ss"],
-    "extends": [
-        "stylelint-config-recommended-scss"
-    ],
-    "defaultSeverity": "warning",
-    "rules": {
-      "no-duplicate-selectors": null,
-      "no-descending-specificity": null,
-      "block-no-empty": null
-    }
+  "ignoreFiles": ["node_modules/**/*.s+(a|c)ss"],
+  "extends": [
+    "stylelint-config-recommended-scss"
+  ],
+  "defaultSeverity": "warning",
+  "rules": {
+    "no-duplicate-selectors": null,
+    "no-descending-specificity": null,
+    "block-no-empty": null,
+    "no-empty-source": [true,
+      {
+        "message": "Empty source. Please add a comment to the source file."
+      }
+    ]
   }
+}


### PR DESCRIPTION
Sometimes we have empty source `.scss` files that need to be included. This adds a message requiring people to add a comment  to these files in order  for them to pass stylelint checks.