### PR TITLE
Fix truskins on slow networks

### DIFF
--- a/src/truskin-page-skin/web/index.js
+++ b/src/truskin-page-skin/web/index.js
@@ -1,15 +1,14 @@
-(function () {
-    let parentBody = window.parent.document.body;
-    parentBody.style.backgroundImage='url(%%VIEW_URL_UNESC%%[%PageSkinFileName%])';
-    parentBody.classList.add('truskin-page-skin');
-    parentBody.style.backgroundAttachment='fixed';
-    parentBody.style.backgroundPosition='50% 0';
-    parentBody.style.backgroundRepeat='no-repeat no-repeat';
-    parentBody.onclick=function(e) {
-        const target = e.target;
-        if (target.nodeName.toLowerCase() === 'body') {
-            window.open('%%CLICK_URL_UNESC%%[%ClickDestination%]');
-        }
-        return true;
-    };
-})();
+let parentBody = window.parent.document.body;
+parentBody.style.backgroundImage='url(%%VIEW_URL_UNESC%%[%PageSkinFileName%])';
+parentBody.style.backgroundAttachment='fixed';
+parentBody.style.backgroundPosition='50% 0';
+parentBody.style.backgroundRepeat='no-repeat no-repeat';
+parentBody.onclick=function(e) {
+    const target = e.target;
+    if (target.nodeName.toLowerCase() === 'body') {
+        window.open('%%CLICK_URL_UNESC%%[%ClickDestination%]');
+    }
+    return true;
+};
+
+window.top.postMessage('truskinRendered', '*');

--- a/src/truskin-page-skin/web/index.js
+++ b/src/truskin-page-skin/web/index.js
@@ -1,4 +1,4 @@
-let parentBody = window.parent.document.body;
+let parentBody = window.top.document.body;
 parentBody.style.backgroundImage='url(%%VIEW_URL_UNESC%%[%PageSkinFileName%])';
 parentBody.style.backgroundAttachment='fixed';
 parentBody.style.backgroundPosition='50% 0';


### PR DESCRIPTION
This is a fix for truskins which went out of sync on slow networks. The truskin was not working as expected because the fabric & the truskin weren't loaded at the same time. Sending an event to the frontend from the commercial template makes sure both are rendered before we do the calculations for repositioning them

Co-authored-by: Josh Buckland <buck06191@gmail.com>