### PR TITLE
Add Page-skin template into commercial templates & introduce event

### DIFF
--- a/src/page-skin/test.json
+++ b/src/page-skin/test.json
@@ -1,0 +1,4 @@
+{
+  "BackgroundImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDrrun_ZRABGAEyCKFQSaYU8JaG",
+  "ClickthroughUrl": "https://www.google.co.uk/",
+}

--- a/src/page-skin/test.json
+++ b/src/page-skin/test.json
@@ -1,4 +1,0 @@
-{
-  "BackgroundImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDrrun_ZRABGAEyCKFQSaYU8JaG",
-  "ClickthroughUrl": "https://www.google.co.uk/",
-}

--- a/src/page-skin/web/index.js
+++ b/src/page-skin/web/index.js
@@ -1,0 +1,17 @@
+var parentBody = window.top.document.body;
+parentBody.style.backgroundImage='url(%%VIEW_URL_UNESC%%https://adimage.theguardian.com/pageskins/[%PageSkinFileName%])';
+parentBody.style.backgroundAttachment='fixed';
+parentBody.style.backgroundPosition='50% 0';
+parentBody.style.backgroundRepeat='no-repeat no-repeat';
+parentBody.onclick=function(e) {
+    var target = e.target;
+    if (target.nodeName.toLowerCase() === 'body') {
+        window.open('%%CLICK_URL_UNESC%%[%ClickDestination%]');
+    }
+    return true;
+};
+var trackingPixel = '[%TrackingPixel%]';
+if (trackingPixel) {
+    (new Image()).src = trackingPixel;
+}
+window.top.postMessage('pageskinRendered', '*');

--- a/src/page-skin/web/index.scss
+++ b/src/page-skin/web/index.scss
@@ -1,0 +1,1 @@
+// Scss rules not required to be different from default.


### PR DESCRIPTION
- Currently 'Skin for front pages' templates is just living in Ad Manager. As an attempt to version control it we copied it in commercial-templates repo.

- Also adding a postMessage event to send an event to the frontend that the pageskin has been rendered 