### PR TITLE
Add climate colours to manual multiple & manual single templates

### DIFF
--- a/src/_shared/scss/_adverts-climate.scss
+++ b/src/_shared/scss/_adverts-climate.scss
@@ -1,0 +1,92 @@
+.adverts--tone-climates {
+    > .adverts__header {
+        background: $news-garnett-highlight;
+        .button {
+            border-color: fade-out($news-garnett-highlight, .7);
+
+            &:hover,
+            &:focus,
+            &:active {
+                border-color: $news-garnett-highlight;
+            }
+        }
+    }
+
+    .adverts__logo {
+        color: $news-garnett-highlight;
+    }
+
+   .adverts__logo .icon {
+        fill: $guardian-brand-dark;
+    }
+
+    .inline-commercial-brand svg {
+        fill: $news-garnett-highlight;
+    }
+
+    .button--large {
+        border: none;
+    }
+
+    .adverts__ctas .button--large {
+        background: $guardian-brand-dark;
+        color: white;
+    }
+}
+
+.adverts--tone-climates .button--legacy-single,
+.advert--climate .button {
+    background: $news-garnett-highlight;
+}
+
+.advert--climate {
+    &:hover,
+    &:focus,
+    &:active {
+        .button {
+            background: $guardian-highlight-hover;
+        }
+    }
+}
+
+.adverts--tone-climates .button--legacy-single {
+     &:hover,
+     &:focus,
+     &:active {
+         background: $guardian-highlight-hover;
+     }
+ }
+
+.adverts--tone-climates .adverts__ctas .button--large {
+    &:hover,
+    &:focus,
+    &:active {
+         background: $neutral-1;
+    }
+}
+
+.advert-blended--climate {
+    .advert-blended__title {
+        padding-top: 5px;
+        padding-bottom: 9px;
+
+        > svg {
+            height: 22px;
+            width: 144px;
+        }
+    }
+
+    .advert {
+        display: block;
+    }
+
+    .advert__image-container {
+        float: right;
+        margin: 0 0 0 $gs-gutter / 2;
+        width: 50%;
+    }
+
+    .icon--logo-climatees {
+        fill: $news-garnett-highlight;
+    }
+}

--- a/src/_shared/scss/_palette.scss
+++ b/src/_shared/scss/_palette.scss
@@ -128,4 +128,5 @@ $guardian-generic-rebrand:     #012937;
 $guardian-weekly-rebrand:     #2c363b;
 $guardian-members-rebrand:     #bb3a7f;
 $news-garnett-highlight: #ffe500;
-$guardian-patron: #4f5249
+$guardian-patron: #4f5249;
+$guardian-highlight-hover: #F2AE00;

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -86,5 +86,6 @@
         'members': '{{#svg}}guardian-members-logo{{/svg}}',
         'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
         'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
+        'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
     };
 </script>

--- a/src/manual-multiple/web/index.scss
+++ b/src/manual-multiple/web/index.scss
@@ -19,3 +19,4 @@
 @import '_adverts-members';
 @import '_adverts-patron';
 @import '_adverts-lifestyle';
+@import '_adverts-climate';

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -52,5 +52,6 @@
         'members': '{{#svg}}guardian-members-logo{{/svg}}',
         'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
         'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
+        'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
     };
 </script>

--- a/src/manual-single/web/index.scss
+++ b/src/manual-single/web/index.scss
@@ -18,3 +18,4 @@
 @import '_adverts-members';
 @import '_adverts-patron';
 @import '_adverts-lifestyle';
+@import '_adverts-climate';


### PR DESCRIPTION
Australian team has requested to create a new manual template with the Climate Pledge colours to be used to keep the climate pledge message going in the wake of bush fire crisis, and they thought a merch slot would be worth testing.



### Screenshots

### Manual Single
![Screenshot 2020-02-26 at 14 48 39](https://user-images.githubusercontent.com/51630004/75357638-98882d00-58a9-11ea-8ad8-5668eef4928c.png)

### Manual Multiple
![Screenshot 2020-02-26 at 14 48 26](https://user-images.githubusercontent.com/51630004/75357656-9f16a480-58a9-11ea-8ccf-64a578ca664e.png)
