### PR TITLE
Native traffic fix for australia

### DIFF
--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -106,8 +106,12 @@ function getWebfonts(fontFamilies) {
 function resizeIframeHeight(height = -1) {
     return height === -1 ?
         timeout(Promise.all(areImagesLoaded().concat(isDocumentLoaded())), 3000)
-        .then(() => read(() => document.body.getBoundingClientRect().height))
+        .then(() => {
+            console.log("*** Images loaded in under 3 seconds")
+            read(() => document.body.getBoundingClientRect().height)
+        })
         .then(function(height) {
+            console.log("*** Boundling client was obtained in time")
             return sendMessage('resize', { height });
         }) :
         sendMessage('resize', { height });

--- a/src/_shared/js/messages.js
+++ b/src/_shared/js/messages.js
@@ -107,11 +107,9 @@ function resizeIframeHeight(height = -1) {
     return height === -1 ?
         timeout(Promise.all(areImagesLoaded().concat(isDocumentLoaded())), 3000)
         .then(() => {
-            console.log("*** Images loaded in under 3 seconds")
-            read(() => document.body.getBoundingClientRect().height)
+            return read(() => document.body.getBoundingClientRect().height)
         })
         .then(function(height) {
-            console.log("*** Boundling client was obtained in time")
             return sendMessage('resize', { height });
         }) :
         sendMessage('resize', { height });

--- a/src/glabs-native-traffic-driver/web/index.js
+++ b/src/glabs-native-traffic-driver/web/index.js
@@ -46,8 +46,7 @@ function buildFromCapi (host, { articleHeadline, articleText, articleUrl, articl
 
 reportClicks();
 enableToggles();
-getIframeId()
-.then(({ host }) => {
+getIframeId().then(({ host }) => {
     return Promise.all([
         getWebfonts(['GuardianTextSansWeb', 'GuardianSansWeb']),
         retrieveCapiData()
@@ -56,5 +55,4 @@ getIframeId()
             addTrackingPixel(document.getElementById('creative'));
         })
     ])
-})
-.then(() => resizeIframeHeight());
+}).then(() => resizeIframeHeight());


### PR DESCRIPTION
Native traffic drivers were failing to resize in Australia. This seems to be because an explicit return statement was required as is now seen on [line 110 of `src/_shared/js/messages.js`](https://github.com/guardian/commercial-templates/compare/native-traffic-fix-for-australia?expand=1#diff-464152bc8d3f5065a5d49485bb558a3bR110).

Adding this in appears to have fixed the problem, which has been tested using browserstack against a machine in Australia as well as against UK machines.