### PR TITLE
Sw viewabiltiy tracking issue

### DIFF
--- a/src/interscroller/test.json
+++ b/src/interscroller/test.json
@@ -1,4 +1,4 @@
 {
   "BackgroundImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDrrun_ZRABGAEyCKFQSaYU8JaG",
-  "ClickthroughUrl": "https://www.google.co.uk/",
+  "ClickthroughUrl": "https://www.google.co.uk/"
 }

--- a/src/interscroller/web/index.html
+++ b/src/interscroller/web/index.html
@@ -1,5 +1,5 @@
 <div class="creative--interscroller">
-    <img src="[%TrackingPixel%]" class="creative__pixel">
-    <img src="[%ResearchPixel%]" class="creative__pixel">
-    <img src="[%ViewabilityTracker%]" class="creative__pixel">
+    <img src="[%TrackingPixel%]" class="creative__pixel creative__pixel--displayNone">
+    <img src="[%ResearchPixel%]" class="creative__pixel creative__pixel--displayNone">
+    <img src="[%ViewabilityTracker%]" class="creative__pixel creative__pixel--displayNone">
 </div>

--- a/src/interscroller/web/index.js
+++ b/src/interscroller/web/index.js
@@ -1,4 +1,4 @@
-import { getIframeId, sendMessage, onViewport } from '../../_shared/js/messages.js';
+import { getIframeId, sendMessage,resizeIframeHeight, onViewport } from '../../_shared/js/messages.js';
 import { once } from '../../_shared/js/utils';
 
 const updateBackground = () => {
@@ -28,6 +28,5 @@ const updateBackground = () => {
 };
 
 getIframeId()
-.then(() => {
-    onViewport(once(updateBackground));
-});
+.then(() => {onViewport(once(updateBackground));})
+.then(() => resizeIframeHeight('85vh'));

--- a/src/interscroller/web/index.scss
+++ b/src/interscroller/web/index.scss
@@ -3,3 +3,7 @@
 .creative--interscroller {
     margin-top: 24px;
 }
+
+.creative__pixel--displayNone {
+    display: none;
+}


### PR DESCRIPTION
## What does this change?
For the Interscroller format the creative is injected further up the page via frontend and the iframe height was not been set, which was causing an issue with the activeView impression firing.

## How to test
Test format setup at 

https://admanager.google.com/59666047#creatives/custom_native_style/detail/styleid=400193

Adtest on production
https://www.theguardian.com/fashion/2020/nov/04/put-my-own-makeup-on-for-the-first-time?dcr=false&adtest=ArmaniEAGent2

## How can we measure success?
Should be able to see the activeView event firing.


## Have we considered potential risks?
Needs to be tested on mobile devices, but I can't see any potential risks.



