### PR TITLE
Added brand-new tone

### DIFF
--- a/src/_shared/scss/_adverts-brand-new.scss
+++ b/src/_shared/scss/_adverts-brand-new.scss
@@ -1,0 +1,33 @@
+.adverts--tone-brand-news.adverts--legacy-single {
+    > .adverts__header {
+        background: $news-main-1;
+    }
+    .adverts__ctas, .advert__more.button.button--small, .advert__image-container {
+        display:none;
+    }
+
+}
+
+
+.adverts--tone-brand-news .button--legacy-single,
+.advert--brand .button {
+    background: $guardian-generic-rebrand;
+    color: #ffffff;
+}
+
+.adverts--tone-brand-news.adverts--legacy-single .button--legacy-single,
+.adverts--legacy-single .advert--brand .button {
+    background: $news-garnett-highlight;
+    color: $guardian-brand-dark;
+}
+
+
+.adverts--tone-brand-news.adverts--legacy-single .button--legacy-single {
+    border: none;
+    &:hover,
+    &:focus,
+    &:active {
+        border-color: $news-garnett-highlight;
+    }
+}
+

--- a/src/manual-single/test.json
+++ b/src/manual-single/test.json
@@ -1,7 +1,7 @@
 {
     "ClickthroughUrl": "",
     "OmnitureId": "",
-    "Tone": "patron",
+    "Tone": "brand-new",
     "Title": "The Guardian Live",
     "TitleURL": "https://theguardian.com/uk",
     "Explainer": "Discussions and interviews",

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -1,57 +1,58 @@
 
 <aside class="adverts advert--manual adverts--legacy adverts--legacy-single adverts--[%Tone%]s adverts--tone-[%Tone%]s" data-link-name="creative | ad single manual | [%OmnitureId%]">
-  <header class="adverts__header">
-      <h1 class="adverts__title">
-          <a class="adverts__logo brand_logo" href="%%CLICK_URL_UNESC%%[%TitleURL%]" data-link-name="title" target="_top"></a>
-      </h1>
-      <div class="adverts_blurb">
-        <span class="adverts__blurb">[%Explainer%]</span>
-      </div>
-      <div class="adverts__ctas">
-          <a class="button button--large button--bordered" href="%%CLICK_URL_UNESC%%[%TitleURL%]" data-link-name="view-all" target="_top">
-              [%ViewAll%]
-              {{#svg}}arrow-right{{/svg}}
-          </a>
-      </div>
-  </header>
-    <div class="adverts__body">
-        <div class="adverts__row">
-            <a class="blink advert advert--single advert--landscape advert--large advert--inverse advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%OfferURL%]" data-link-name="[%OfferTitle%]" target="_top">
-                <div class="advert__text">
-                  <h2 class="blink__anchor advert__title">[%OfferTitle%]</h2>
-                  <p class="advert__standfirst">[%OfferText%]</p>
-                  <span class="advert__more button button--small">
-                      [%OfferLinkText%]
-                      {{#svg}}arrow-right{{/svg}}
-                  </span>
-                </div>
-                <div class="advert__image-container">
-                      <img class="advert__image" src="[%OfferImage%]" alt>
-                </div>
-            </a>
-            <a class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" href="%%CLICK_URL_ESC%%[%TitleURL%]"  data-link-name="viewall" target="_top">
+    <header class="adverts__header">
+        <h1 class="adverts__title">
+            <a class="adverts__logo brand_logo" href="%%CLICK_URL_UNESC%%[%TitleURL%]" data-link-name="title" target="_top"></a>
+        </h1>
+        <div class="adverts_blurb">
+          <span class="adverts__blurb">[%Explainer%]</span>
+        </div>
+        <div class="adverts__ctas">
+            <a class="button button--large button--bordered" href="%%CLICK_URL_UNESC%%[%TitleURL%]" data-link-name="view-all" target="_top">
                 [%ViewAll%]
                 {{#svg}}arrow-right{{/svg}}
             </a>
         </div>
-    </div>
-</aside>
-
-<script>
-    var logoSvgs = {
-        'job': '{{#svg}}guardian-jobs-logo{{/svg}}',
-        'live': '{{#svg}}guardian-live-logo{{/svg}}',
-        'travel': '{{#svg}}guardian-holidays-logo{{/svg}}',
-        'money': '{{#svg}}guardian-moneydeals-logo{{/svg}}',
-        'book': '{{#svg}}guardian-bookshop-logo{{/svg}}',
-        'masterclass': '{{#svg}}guardian-masterclasses-logo{{/svg}}',
-        'subscription': '{{#svg}}guardian-subscriptions-logo{{/svg}}',
-        'brand': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
-        'members': '{{#svg}}guardian-members-logo{{/svg}}',
-        'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
-        'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'support': '{{#svg}}guardian-generic-logo{{/svg}}',
-    };
-</script>
+    </header>
+      <div class="adverts__body">
+          <div class="adverts__row">
+              <a class="blink advert advert--single advert--landscape advert--large advert--inverse advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%OfferURL%]" data-link-name="[%OfferTitle%]" target="_top">
+                  <div class="advert__text">
+                    <h2 class="blink__anchor advert__title">[%OfferTitle%]</h2>
+                    <p class="advert__standfirst">[%OfferText%]</p>
+                    <span class="advert__more button button--small">
+                        [%OfferLinkText%]
+                        {{#svg}}arrow-right{{/svg}}
+                    </span>
+                  </div>
+                  <div class="advert__image-container">
+                        <img class="advert__image" src="[%OfferImage%]" alt>
+                  </div>
+              </a>
+              <a class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" href="%%CLICK_URL_ESC%%[%TitleURL%]"  data-link-name="viewall" target="_top">
+                  [%ViewAll%]
+                  {{#svg}}arrow-right{{/svg}}
+              </a>
+          </div>
+      </div>
+  </aside>
+  
+  <script>
+      var logoSvgs = {
+          'job': '{{#svg}}guardian-jobs-logo{{/svg}}',
+          'live': '{{#svg}}guardian-live-logo{{/svg}}',
+          'travel': '{{#svg}}guardian-holidays-logo{{/svg}}',
+          'money': '{{#svg}}guardian-moneydeals-logo{{/svg}}',
+          'book': '{{#svg}}guardian-bookshop-logo{{/svg}}',
+          'masterclass': '{{#svg}}guardian-masterclasses-logo{{/svg}}',
+          'subscription': '{{#svg}}guardian-subscriptions-logo{{/svg}}',
+          'brand': '{{#svg}}guardian-generic-logo{{/svg}}',
+          'brand-new': '{{#svg}}guardian-generic-logo{{/svg}}',
+          'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
+          'members': '{{#svg}}guardian-members-logo{{/svg}}',
+          'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
+          'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
+          'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
+          'support': '{{#svg}}guardian-generic-logo{{/svg}}'
+      };
+  </script>

--- a/src/manual-single/web/index.scss
+++ b/src/manual-single/web/index.scss
@@ -5,6 +5,7 @@
 @import '_adverts-jobs';
 @import '_adverts-capi';
 @import '_adverts-brand';
+@import '_adverts-brand-new';
 @import '_adverts-membership';
 @import '_adverts-travel';
 @import '_adverts-subscriptions';


### PR DESCRIPTION
## What does this change?
We've created a `brand-new` tone for the `manual-single` template following the specifications as requested by the BRR team. This will allow them to test and learn about contributions and digital subscriptions.

## Images
**Before**
![image](https://user-images.githubusercontent.com/57295823/114199380-26a76180-994c-11eb-88b2-fbca6e4e8f0c.png)
**After** 
![image](https://user-images.githubusercontent.com/57295823/114199482-3fb01280-994c-11eb-8b2d-7d1d63cfc9d0.png)

