### PR TITLE
remove SVG duplication

### DIFF
--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -38,6 +38,9 @@
   </aside>
   
   <script>
+      const genericLogoTones = ['brand', 'brand-new', 'lifestyle', 'climate', 'support']
+      const genericLogoString = '{{#svg}}guardian-generic-logo{{/svg}}'
+      
       var logoSvgs = {
           'job': '{{#svg}}guardian-jobs-logo{{/svg}}',
           'live': '{{#svg}}guardian-live-logo{{/svg}}',
@@ -46,13 +49,9 @@
           'book': '{{#svg}}guardian-bookshop-logo{{/svg}}',
           'masterclass': '{{#svg}}guardian-masterclasses-logo{{/svg}}',
           'subscription': '{{#svg}}guardian-subscriptions-logo{{/svg}}',
-          'brand': '{{#svg}}guardian-generic-logo{{/svg}}',
-          'brand-new': '{{#svg}}guardian-generic-logo{{/svg}}',
           'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
           'members': '{{#svg}}guardian-members-logo{{/svg}}',
           'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
-          'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
-          'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
-          'support': '{{#svg}}guardian-generic-logo{{/svg}}'
+          ...Object.fromEntries(genericLogoTones.map(tone => [tone, genericLogoString]))
       };
   </script>


### PR DESCRIPTION
## What does this change?
There were five tones using the `guardian-generic-logo` SVG. 
This removes duplicates, reducing the build size from 72KB to 62KB.

## How can we measure success?
Smaller code.

## Images
No visual changes.
