### PR TITLE
Msav/svg dedup

### DIFF
--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -71,10 +71,7 @@
         </div>
     </div>
 </aside>
-<script>
-    const genericLogoTones = ['brand', 'lifestyle', 'climate', 'climate2', 'support']
-    const subscriptionsLogoTones = ['subscription', 'subs-rebrand']
-    
+<script>    
     const genericLogoString = '{{#svg}}guardian-generic-logo{{/svg}}'
     const subscriptionsLogoString = '{{#svg}}guardian-subscriptions-logo{{/svg}}'
 
@@ -88,7 +85,12 @@
         'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
         'members': '{{#svg}}guardian-members-logo{{/svg}}',
         'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
-        ...Object.fromEntries(genericLogoTones.map(tone => [tone, genericLogoString])),
-        ...Object.fromEntries(subscriptionsLogoTones.map(tone => [tone, subscriptionsLogoString]))
+        'brand': genericLogoString,
+        'lifestyle': genericLogoString,
+        'climate': genericLogoString,
+        'climate2': genericLogoString,
+        'support': genericLogoString,
+        'subscription': subscriptionsLogoString,
+        'subs-rebrand': subscriptionsLogoString
     };
 </script>

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -72,6 +72,12 @@
     </div>
 </aside>
 <script>
+    const genericLogoTones = ['brand', 'lifestyle', 'climate', 'climate2', 'support']
+    const subscriptionsLogoTones = ['subscription', 'subs-rebrand']
+    
+    const genericLogoString = '{{#svg}}guardian-generic-logo{{/svg}}'
+    const subscriptionsLogoString = '{{#svg}}guardian-subscriptions-logo{{/svg}}'
+
     var logoSvgs = {
         'job': '{{#svg}}guardian-jobs-logo{{/svg}}',
         'live': '{{#svg}}guardian-live-logo{{/svg}}',
@@ -79,15 +85,10 @@
         'money': '{{#svg}}guardian-moneydeals-logo{{/svg}}',
         'book': '{{#svg}}guardian-bookshop-logo{{/svg}}',
         'masterclass': '{{#svg}}guardian-masterclasses-logo{{/svg}}',
-        'subscription': '{{#svg}}guardian-subscriptions-logo{{/svg}}',
-        'brand': '{{#svg}}guardian-generic-logo{{/svg}}',
         'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
         'members': '{{#svg}}guardian-members-logo{{/svg}}',
         'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
-        'lifestyle': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'climate': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'climate2': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'support': '{{#svg}}guardian-generic-logo{{/svg}}',
-        'subs-rebrand': '{{#svg}}guardian-subscriptions-logo{{/svg}}',
+        ...Object.fromEntries(genericLogoTones.map(tone => [tone, genericLogoString])),
+        ...Object.fromEntries(subscriptionsLogoTones.map(tone => [tone, subscriptionsLogoString]))
     };
 </script>

--- a/src/manual-single/web/index.html
+++ b/src/manual-single/web/index.html
@@ -38,7 +38,6 @@
   </aside>
   
   <script>
-      const genericLogoTones = ['brand', 'brand-new', 'lifestyle', 'climate', 'support']
       const genericLogoString = '{{#svg}}guardian-generic-logo{{/svg}}'
       
       var logoSvgs = {
@@ -52,6 +51,10 @@
           'weekly': '{{#svg}}guardian-weekly-logo{{/svg}}',
           'members': '{{#svg}}guardian-members-logo{{/svg}}',
           'patron': '{{#svg}}guardian-patron-logo{{/svg}}',
-          ...Object.fromEntries(genericLogoTones.map(tone => [tone, genericLogoString]))
-      };
+          'brand': genericLogoString,
+          'brand-new': genericLogoString,
+          'lifestyle': genericLogoString,
+          'climate': genericLogoString,
+          'support': genericLogoString
+      }
   </script>


### PR DESCRIPTION
## What does this change?
Both the `guardian-generic-logo` and `guardian-subscriptions-logo` SVGs were duplicated several times in  `manual-multiple` template (the generic logo was loaded five times and the subscriptions logo twice). 
This change simplifies the code so the build size of is reduced from 87KB to 64KB (26% reduction).

## How can we measure success?
More succinct code, smaller size.

## Images
No visual changes, but I'm adding screenshots for both logos to show that this change doesn't affect the rendering of the SVGs. Examples:

`subs-rebrand` tone

![image](https://user-images.githubusercontent.com/57295823/114708882-d5b8b400-9d23-11eb-83ce-79d3f57ef77e.png)

`climate` tone

![image](https://user-images.githubusercontent.com/57295823/114709011-fb45bd80-9d23-11eb-8a02-31fcea33871c.png)
