### PR TITLE
Msav/meta text colour

### DIFF
--- a/src/_shared/scss/_advert.scss
+++ b/src/_shared/scss/_advert.scss
@@ -101,6 +101,7 @@
     .advert__standfirst {
         margin-top: $gs-baseline / 2;
         opacity: .7;
+        color: $guardian-brand-dark;
     }
 
     .advert__image {
@@ -167,7 +168,7 @@
 
 .advert__meta {
     font-family: $f-sans-serif-text;
-    color: $neutral-2;
+    color: $guardian-brand-dark;
 }
 
 .advert__meta--scarcity {

--- a/src/_shared/scss/_advert.scss
+++ b/src/_shared/scss/_advert.scss
@@ -100,7 +100,6 @@
 
     .advert__standfirst {
         margin-top: $gs-baseline / 2;
-        opacity: .7;
         color: $guardian-brand-dark;
     }
 


### PR DESCRIPTION
## What does this change?
This changes the colour of meta and offer text from 
![image](https://user-images.githubusercontent.com/57295823/117297554-4740d980-ae6e-11eb-9109-90da3d3faf73.png) (#767676) light grey 
to 
![image](https://user-images.githubusercontent.com/57295823/117297471-2e382880-ae6e-11eb-852e-963dc3b52d50.png) (#121212) dark grey
in the single and multiple merchandising templates.

This is so the contrast check passes, as the light grey tone didn't have enough contrast against the background.

## Images

`manual-single` before

![image](https://user-images.githubusercontent.com/57295823/117296626-2cba3080-ae6d-11eb-903e-b45d40a165b8.png)
`manual-single` after

![image](https://user-images.githubusercontent.com/57295823/117296907-7efb5180-ae6d-11eb-8e5e-9ffbc6d23b39.png)

`manual-multiple` before

![image](https://user-images.githubusercontent.com/57295823/117297175-d1d50900-ae6d-11eb-8962-217db0b4326f.png)
`manual-multiple` after

![image](https://user-images.githubusercontent.com/57295823/117297083-b1a54a00-ae6d-11eb-8538-f2417692be89.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
