### PR TITLE
Adding an extra tracking field within fabric templates for adops to use JS tracking tags

### DIFF
--- a/src/fabric-custom/test.json
+++ b/src/fabric-custom/test.json
@@ -3,5 +3,6 @@
   "ThirdPartyTag": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrtKGjoAEQARgBMgjYagW3ARF6Fw",
   "TrackingPixel": "https://gu.com/tracking-pixel.gif",
   "ResearchPixel": "https://gu.com/research-pixel.gif",
-  "ViewabilityTracker": "<img src='https://gu.com/viewability-tracker.gif'>"
+  "ViewabilityTracker": "<img src='https://gu.com/viewability-tracker.gif'>",
+  "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>"
 }

--- a/src/fabric-custom/web/index.html
+++ b/src/fabric-custom/web/index.html
@@ -7,3 +7,4 @@
   <img src="[%ResearchPixel%]" class="creative__pixel">
   <img src="[%ViewabilityTracker%]" class="creative__pixel">
 <div>
+[%thirdPartyJSTracking%]

--- a/src/fabric-video-expandable/test.json
+++ b/src/fabric-video-expandable/test.json
@@ -63,5 +63,6 @@
   "YoutubeVimeoIframeEmbedURL": "https://player.vimeo.com/video/206560728",
   "VideoOptions": "right-aligned",
   "ShowMoreType": "arrow",
-  "PlusIconAlignment": "to-screen"
+  "PlusIconAlignment": "to-screen",
+  "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>"
 }

--- a/src/fabric-video-expandable/web/index.html
+++ b/src/fabric-video-expandable/web/index.html
@@ -86,3 +86,4 @@
 
     <img src="[%Trackingpixel%]" class="creative__pixel">
 </div>
+[%thirdPartyJSTracking%]

--- a/src/fabric-video/test.json
+++ b/src/fabric-video/test.json
@@ -27,5 +27,6 @@
     "VideoAlignment": "center",
     "Trackingpixel": "",
     "Researchpixel": "",
-    "Viewabilitypixel": ""
+    "Viewabilitypixel": "",
+    "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>"
 }

--- a/src/fabric-video/web/index.html
+++ b/src/fabric-video/web/index.html
@@ -34,3 +34,4 @@
     <img src="[%Researchpixel%]" class="creative__pixel">
     <img src="[%Viewabilitypixel%]" class="creative__pixel">
 </div>
+[%thirdPartyJSTracking%]

--- a/src/fabric/test.json
+++ b/src/fabric/test.json
@@ -3,6 +3,7 @@
   "Trackingpixel": "",
   "Researchpixel": "",
   "Viewabilitypixel": "",
+  "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>",
   "BackgroundScrollType": "fixed",
   "BackgroundColour": "transparent",
   "BackgroundImage": "",

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -42,3 +42,4 @@
     <img src="[%Researchpixel%]" class="creative__pixel">
     <img src="[%Viewabilitypixel%]" class="creative__pixel">
 </div>
+[%[%thirdPartyJSTracking%]%]

--- a/src/fabric/web/index.html
+++ b/src/fabric/web/index.html
@@ -42,4 +42,4 @@
     <img src="[%Researchpixel%]" class="creative__pixel">
     <img src="[%Viewabilitypixel%]" class="creative__pixel">
 </div>
-[%[%thirdPartyJSTracking%]%]
+[%thirdPartyJSTracking%]


### PR DESCRIPTION


## What does this change?
Historically we have versions of the main Fabric native styles that have an extra open field after Adops requested it to add Moat JS tracking tags.

https://admanager.google.com/59666047#creatives/custom_native_style/detail/styleid=278072

Adops now use Moat and other JS tracking tags with more frequency that it makes sense to just add the extra field to all the standard Fabric templates and just have the one template.  

## How to test
test.json has an example tracking tag from Adops, should see the tag render in the preview, appended to the foot of the template.

## How can we measure success?
Currently we sometimes have to re upload creatives to the Moat version when tracking comes over from client. With the extra field as standard it should cut down on this and the extra time spent.




