### PR TITLE
Update native ad header alignment

### DIFF
--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -1,12 +1,13 @@
 @mixin separator($colour, $left, $margin-left: 0) {
     content: '';
     position: absolute;
-    left: $left;
+    left: 0;
     top: 0;
     bottom: 0;
     margin-left: $margin-left;
     width: 1px;
     background: $colour;
+    box-sizing: border-box;
 }
 
 .adverts {
@@ -117,17 +118,20 @@
     }
 
     > .adverts__body {
+        max-width: 100%;
+        box-sizing: border-box;
         padding-bottom: $gs-baseline;
 
         @include mq(mobileLandscape) {
             box-sizing: border-box;
-            max-width: gs-span(8) + ($gs-gutter * 2);
         }
-        @include mq(tablet) {
-            max-width: gs-span(9) + ($gs-gutter * 2);
+
+        @include mq(leftCol) {
+            margin-right: $gs-gutter/2 + 1px;
         }
-        @include mq(desktop) {
-            max-width: gs-span(12) + ($gs-gutter * 2);
+
+        @include mq(wide) {
+            margin-right: $gs-gutter + 70px + 1px;
         }
     }
 
@@ -187,6 +191,10 @@
 
     .advert {
         position: relative;
+    }
+
+    .advert__content {
+        padding: 10px;
     }
 
     /* [1] Forces text wrap in IE11 */

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -303,9 +303,13 @@
         flex-basis: calc(100% - #{$gs-gutter});
     }
 
+    .button--legacy-single {
+        margin-left: $gs-gutter;
+    }
+
     @include mq(mobileLandscape) {
         .advert {
-            flex-basis: calc(75% - #{$gs-gutter});
+            flex-basis: calc(75% - #{$gs-gutter/2});
             flex-grow: 0;
         }
 
@@ -330,7 +334,7 @@
 
     .has-no-flex & {
         .advert {
-            width: calc(75% - #{$gs-gutter});
+            width: calc(75% - #{$gs-gutter/2});
         }
 
         .advert--landscape > .advert__image-container {

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -66,7 +66,8 @@
         > .adverts__header {
             box-sizing: border-box;
             padding: $gs-baseline $gs-gutter / 5 * 2;
-            width: 160px;
+            // Extra 1px to line up with borders on sections above / below
+            width: 160px + $gs-gutter/2 + 1px;
         }
 
         > .adverts__body {
@@ -89,7 +90,8 @@
     @include mq(wide) {
         > .adverts__header {
             padding: $gs-baseline $gs-gutter;
-            width: 240px;
+            // Extra 1px to line up with borders on sections above / below
+            width: 240px + $gs-gutter/2 + 1px;
         }
 
         .adverts__ctas {

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -205,12 +205,10 @@
     }
 
     .adverts__row {
-        padding: $gs-baseline / 2 0;
+        padding: $gs-baseline $gs-gutter/2;
         display: flex;
 
         > * {
-            margin: 0 $gs-gutter / 2;
-
             /* In Firefox, flex items have a min-width: auto, which prevents
                them from shrinking when they have an image larger than the
                size the item would normally fill. The only workaround to
@@ -243,8 +241,6 @@
         }
 
         @include mq(tablet) {
-            padding: $gs-baseline $gs-gutter / 2;
-
             > * + * {
                 position: relative;
 
@@ -275,6 +271,10 @@
                     width: calc(50% - #{$gs-gutter});
                 }
             }
+        }
+        
+        @include mq(leftCol) {
+            padding: $gs-baseline 0;
         }
     }
 

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -7,7 +7,6 @@
     margin-left: $margin-left;
     width: 1px;
     background: $colour;
-    box-sizing: border-box;
 }
 
 .adverts {
@@ -191,7 +190,6 @@
 
     .advert {
         position: relative;
-        padding: 0px $gs-gutter/2;
     }
 
     /* [1] Forces text wrap in IE11 */
@@ -206,6 +204,8 @@
         display: flex;
 
         > * {
+            margin: 0 $gs-gutter / 2;
+
             /* In Firefox, flex items have a min-width: auto, which prevents
                them from shrinking when they have an image larger than the
                size the item would normally fill. The only workaround to
@@ -232,7 +232,7 @@
                 position: relative;
 
                 &:nth-child(even)::before {
-                    @include separator($neutral-4, 0px);
+                    @include separator($neutral-4, $gs-gutter / -2);
                 }
             }
         }
@@ -242,7 +242,7 @@
                 position: relative;
 
                 &::before {
-                    @include separator($neutral-4, 0px);
+                    @include separator($neutral-4, $gs-gutter / -2);
                 }
             }
         }
@@ -269,7 +269,8 @@
                 }
             }
         }
-        
+
+                
         @include mq(leftCol) {
             padding: $gs-baseline 0;
         }
@@ -303,13 +304,9 @@
         flex-basis: calc(100% - #{$gs-gutter});
     }
 
-    .button--legacy-single {
-        margin-left: $gs-gutter;
-    }
-
     @include mq(mobileLandscape) {
         .advert {
-            flex-basis: calc(75% - #{$gs-gutter/2});
+            flex-basis: calc(75% - #{$gs-gutter});
             flex-grow: 0;
         }
 
@@ -334,7 +331,7 @@
 
     .has-no-flex & {
         .advert {
-            width: calc(75% - #{$gs-gutter/2});
+            width: calc(75% - #{$gs-gutter});
         }
 
         .advert--landscape > .advert__image-container {
@@ -446,6 +443,13 @@
 }
 
 .adverts__row {
+    @include mq($until: tablet) {
+        /* http://alistapart.com/article/axiomatic-css-and-lobotomized-owls */
+        > * + * {
+            margin-top: $gs-baseline;
+        }
+    }
+
     @include mq(tablet) {
         display: flex;
         padding: $gs-baseline $gs-gutter / 2 0;

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -67,7 +67,7 @@
             box-sizing: border-box;
             padding: $gs-baseline $gs-gutter / 5 * 2;
             // Extra 1px to line up with borders on sections above / below
-            width: 160px + $gs-gutter/2 + 1px;
+            width: 160px + $gs-gutter / 2 + 1px;
         }
 
         > .adverts__body {
@@ -91,7 +91,7 @@
         > .adverts__header {
             padding: $gs-baseline $gs-gutter;
             // Extra 1px to line up with borders on sections above / below
-            width: 240px + $gs-gutter/2 + 1px;
+            width: 240px + $gs-gutter / 2 + 1px;
         }
 
         .adverts__ctas {
@@ -126,7 +126,7 @@
         }
 
         @include mq(leftCol) {
-            margin-right: $gs-gutter/2 + 1px;
+            margin-right: $gs-gutter / 2 + 1px;
         }
 
         @include mq(wide) {
@@ -200,7 +200,7 @@
     }
 
     .adverts__row {
-        padding: $gs-baseline $gs-gutter/2;
+        padding: $gs-baseline $gs-gutter / 2;
         display: flex;
 
         > * {

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -442,13 +442,6 @@
 }
 
 .adverts__row {
-    @include mq($until: tablet) {
-        /* http://alistapart.com/article/axiomatic-css-and-lobotomized-owls */
-        > * + * {
-            margin-top: $gs-baseline;
-        }
-    }
-
     @include mq(tablet) {
         display: flex;
         padding: $gs-baseline $gs-gutter / 2 0;

--- a/src/_shared/scss/_adverts.scss
+++ b/src/_shared/scss/_adverts.scss
@@ -1,7 +1,7 @@
 @mixin separator($colour, $left, $margin-left: 0) {
     content: '';
     position: absolute;
-    left: 0;
+    left: $left;
     top: 0;
     bottom: 0;
     margin-left: $margin-left;
@@ -191,10 +191,7 @@
 
     .advert {
         position: relative;
-    }
-
-    .advert__content {
-        padding: 10px;
+        padding: 0px $gs-gutter/2;
     }
 
     /* [1] Forces text wrap in IE11 */
@@ -235,7 +232,7 @@
                 position: relative;
 
                 &:nth-child(even)::before {
-                    @include separator($neutral-4, $gs-gutter / -2);
+                    @include separator($neutral-4, 0px);
                 }
             }
         }
@@ -245,7 +242,7 @@
                 position: relative;
 
                 &::before {
-                    @include separator($neutral-4, $gs-gutter / -2);
+                    @include separator($neutral-4, 0px);
                 }
             }
         }

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -17,7 +17,6 @@
     <div class="adverts__body">
         <div class="adverts__row adverts__row--prominent-[%IsProminent%] adverts__row--[%NumberofCards%]cards">
             <a class="blink advert advert--manual advert--prominent-[%IsProminent%] advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer1URL%]" data-link-name="Offer 1 | [%Offer1Title%]" target="_top">
-                <div class="advert__content">
                     <div class="advert__image-container">
                         <img class="advert__image" src="[%Offer1Image%]" alt>
                     </div>
@@ -29,51 +28,44 @@
                             {{#svg}}arrow-right{{/svg}}
                         </span>
                     </div>
-                </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer2URL%]" data-link-name="Offer 2 | [%Offer2Title%]" target="_top">
-                <div class="advert__content">
-                    <div class="advert__image-container">
-                        <img class="advert__image" src="[%Offer2Image%]" alt>
-                    </div>
-                    <div class="advert__text">
-                        <h2 class="blink__anchor advert__title">[%Offer2Title%]</h2>
-                        <div class="advert__meta">[%Offer2Meta%]</div>
-                        <span class="advert__more button button--small">
-                            [%Offer2LinkText%]
-                            {{#svg}}arrow-right{{/svg}}
-                        </span>
-                    </div>
+                <div class="advert__image-container">
+                    <img class="advert__image" src="[%Offer2Image%]" alt>
+                </div>
+                <div class="advert__text">
+                    <h2 class="blink__anchor advert__title">[%Offer2Title%]</h2>
+                    <div class="advert__meta">[%Offer2Meta%]</div>
+                    <span class="advert__more button button--small">
+                        [%Offer2LinkText%]
+                        {{#svg}}arrow-right{{/svg}}
+                    </span>
                 </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%] hide-until-tablet" href="%%CLICK_URL_UNESC%%[%Offer3URL%]" data-link-name="Offer 3 | [%Offer3Title%]" target="_top">
-                <div class="advert__content">
-                    <div class="advert__image-container">
-                        <img class="advert__image" src="[%Offer3Image%]" alt>
-                    </div>
-                    <div class="advert__text">
-                        <h2 class="blink__anchor advert__title">[%Offer3Title%]</h2>
-                        <div class="advert__meta">[%Offer3Meta%]</div>
-                        <span class="advert__more button button--small">
-                            [%Offer3LinkText%]
-                            {{#svg}}arrow-right{{/svg}}
-                        </span>
-                    </div>
+                <div class="advert__image-container">
+                    <img class="advert__image" src="[%Offer3Image%]" alt>
+                </div>
+                <div class="advert__text">
+                    <h2 class="blink__anchor advert__title">[%Offer3Title%]</h2>
+                    <div class="advert__meta">[%Offer3Meta%]</div>
+                    <span class="advert__more button button--small">
+                        [%Offer3LinkText%]
+                        {{#svg}}arrow-right{{/svg}}
+                    </span>
                 </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%] hide-until-tablet" href="%%CLICK_URL_UNESC%%[%Offer4URL%]" data-link-name="Offer 4 | [%Offer4Title%]" target="_top">
-                <div class="advert__content">
-                    <div class="advert__image-container">
-                        <img class="advert__image" src="[%Offer4Image%]" alt>
-                    </div>
-                    <div class="advert__text">
-                        <h2 class="blink__anchor advert__title">[%Offer4Title%]</h2>
-                        <div class="advert__meta">[%Offer4Meta%]</div>
-                        <span class="advert__more button button--small">
-                            [%Offer4LinkText%]
-                            {{#svg}}arrow-right{{/svg}}
-                        </span>
-                    </div>
+                <div class="advert__image-container">
+                    <img class="advert__image" src="[%Offer4Image%]" alt>
+                </div>
+                <div class="advert__text">
+                    <h2 class="blink__anchor advert__title">[%Offer4Title%]</h2>
+                    <div class="advert__meta">[%Offer4Meta%]</div>
+                    <span class="advert__more button button--small">
+                        [%Offer4LinkText%]
+                        {{#svg}}arrow-right{{/svg}}
+                    </span>
                 </div>
             </a>
         </div>

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -17,17 +17,17 @@
     <div class="adverts__body">
         <div class="adverts__row adverts__row--prominent-[%IsProminent%] adverts__row--[%NumberofCards%]cards">
             <a class="blink advert advert--manual advert--prominent-[%IsProminent%] advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer1URL%]" data-link-name="Offer 1 | [%Offer1Title%]" target="_top">
-                    <div class="advert__image-container">
-                        <img class="advert__image" src="[%Offer1Image%]" alt>
-                    </div>
-                    <div class="advert__text">
-                        <h2 class="blink__anchor advert__title">[%Offer1Title%]</h2>
-                        <div class="advert__meta">[%Offer1Meta%]</div>
-                        <span class="advert__more button button--small">
-                            [%Offer1LinkText%]
-                            {{#svg}}arrow-right{{/svg}}
-                        </span>
-                    </div>
+                <div class="advert__image-container">
+                    <img class="advert__image" src="[%Offer1Image%]" alt>
+                </div>
+                <div class="advert__text">
+                    <h2 class="blink__anchor advert__title">[%Offer1Title%]</h2>
+                    <div class="advert__meta">[%Offer1Meta%]</div>
+                    <span class="advert__more button button--small">
+                        [%Offer1LinkText%]
+                        {{#svg}}arrow-right{{/svg}}
+                    </span>
+                </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer2URL%]" data-link-name="Offer 2 | [%Offer2Title%]" target="_top">
                 <div class="advert__image-container">

--- a/src/manual-multiple/web/index.html
+++ b/src/manual-multiple/web/index.html
@@ -17,55 +17,63 @@
     <div class="adverts__body">
         <div class="adverts__row adverts__row--prominent-[%IsProminent%] adverts__row--[%NumberofCards%]cards">
             <a class="blink advert advert--manual advert--prominent-[%IsProminent%] advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer1URL%]" data-link-name="Offer 1 | [%Offer1Title%]" target="_top">
-                <div class="advert__image-container">
-                    <img class="advert__image" src="[%Offer1Image%]" alt>
-                </div>
-                <div class="advert__text">
-                    <h2 class="blink__anchor advert__title">[%Offer1Title%]</h2>
-                    <div class="advert__meta">[%Offer1Meta%]</div>
-                    <span class="advert__more button button--small">
-                        [%Offer1LinkText%]
-                        {{#svg}}arrow-right{{/svg}}
-                    </span>
+                <div class="advert__content">
+                    <div class="advert__image-container">
+                        <img class="advert__image" src="[%Offer1Image%]" alt>
+                    </div>
+                    <div class="advert__text">
+                        <h2 class="blink__anchor advert__title">[%Offer1Title%]</h2>
+                        <div class="advert__meta">[%Offer1Meta%]</div>
+                        <span class="advert__more button button--small">
+                            [%Offer1LinkText%]
+                            {{#svg}}arrow-right{{/svg}}
+                        </span>
+                    </div>
                 </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%]" href="%%CLICK_URL_UNESC%%[%Offer2URL%]" data-link-name="Offer 2 | [%Offer2Title%]" target="_top">
-                <div class="advert__image-container">
-                    <img class="advert__image" src="[%Offer2Image%]" alt>
-                </div>
-                <div class="advert__text">
-                    <h2 class="blink__anchor advert__title">[%Offer2Title%]</h2>
-                    <div class="advert__meta">[%Offer2Meta%]</div>
-                    <span class="advert__more button button--small">
-                        [%Offer2LinkText%]
-                        {{#svg}}arrow-right{{/svg}}
-                    </span>
+                <div class="advert__content">
+                    <div class="advert__image-container">
+                        <img class="advert__image" src="[%Offer2Image%]" alt>
+                    </div>
+                    <div class="advert__text">
+                        <h2 class="blink__anchor advert__title">[%Offer2Title%]</h2>
+                        <div class="advert__meta">[%Offer2Meta%]</div>
+                        <span class="advert__more button button--small">
+                            [%Offer2LinkText%]
+                            {{#svg}}arrow-right{{/svg}}
+                        </span>
+                    </div>
                 </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%] hide-until-tablet" href="%%CLICK_URL_UNESC%%[%Offer3URL%]" data-link-name="Offer 3 | [%Offer3Title%]" target="_top">
-                <div class="advert__image-container">
-                    <img class="advert__image" src="[%Offer3Image%]" alt>
-                </div>
-                <div class="advert__text">
-                    <h2 class="blink__anchor advert__title">[%Offer3Title%]</h2>
-                    <div class="advert__meta">[%Offer3Meta%]</div>
-                    <span class="advert__more button button--small">
-                        [%Offer3LinkText%]
-                        {{#svg}}arrow-right{{/svg}}
-                    </span>
+                <div class="advert__content">
+                    <div class="advert__image-container">
+                        <img class="advert__image" src="[%Offer3Image%]" alt>
+                    </div>
+                    <div class="advert__text">
+                        <h2 class="blink__anchor advert__title">[%Offer3Title%]</h2>
+                        <div class="advert__meta">[%Offer3Meta%]</div>
+                        <span class="advert__more button button--small">
+                            [%Offer3LinkText%]
+                            {{#svg}}arrow-right{{/svg}}
+                        </span>
+                    </div>
                 </div>
             </a>
             <a class="blink advert advert--manual advert--[%Tone%] hide-until-tablet" href="%%CLICK_URL_UNESC%%[%Offer4URL%]" data-link-name="Offer 4 | [%Offer4Title%]" target="_top">
-                <div class="advert__image-container">
-                    <img class="advert__image" src="[%Offer4Image%]" alt>
-                </div>
-                <div class="advert__text">
-                    <h2 class="blink__anchor advert__title">[%Offer4Title%]</h2>
-                    <div class="advert__meta">[%Offer4Meta%]</div>
-                    <span class="advert__more button button--small">
-                        [%Offer4LinkText%]
-                        {{#svg}}arrow-right{{/svg}}
-                    </span>
+                <div class="advert__content">
+                    <div class="advert__image-container">
+                        <img class="advert__image" src="[%Offer4Image%]" alt>
+                    </div>
+                    <div class="advert__text">
+                        <h2 class="blink__anchor advert__title">[%Offer4Title%]</h2>
+                        <div class="advert__meta">[%Offer4Meta%]</div>
+                        <span class="advert__more button button--small">
+                            [%Offer4LinkText%]
+                            {{#svg}}arrow-right{{/svg}}
+                        </span>
+                    </div>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
## What does this change?

This PR fixes a layout issue where the header of native adverts in merchandising slots does not align with sections on the rest of the website. 

The fix is to increase the the width of the header by half a gutter width (and an additional pixel to account for the border drawn by other sections). Additionally the spacing in the advert row and body has been adjusted to account for the change in width of the header.

| Before      | After      |
|-------------|------------|
| ![Screenshot 2021-08-19 at 14 47 44](https://user-images.githubusercontent.com/8000415/130080143-b7c5f2dd-55c3-42c0-831e-64df065822d2.png) | ![Screenshot 2021-08-19 at 14 47 54](https://user-images.githubusercontent.com/8000415/130080192-9767df12-ba8e-4a02-91c9-1e2d8f028a8b.png) |

Note that this does not affect paid for adverts delivered through frontend.

## How to test

Example test ads can be viewed at:
- https://www.theguardian.com/uk?adtest=native-alignment-test (For manual multiple and capi-multiple-paidfor)
- https://www.theguardian.com/uk?adtest=native-alignment-test-single (For manual single)