### PR TITLE
Remove tracking id from Capi Multiple Paid For templates

### DIFF
--- a/src/capi-multiple-paidfor/web/index.html
+++ b/src/capi-multiple-paidfor/web/index.html
@@ -1,5 +1,5 @@
 
-<aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component | [%TrackingId%]">
+<aside class="adverts adverts--legacy adverts--capi adverts--paidfor adverts--tone-paidfor" data-link-name="creative | capi multiple component">
     <header class="adverts__header">
         <div class="adverts__kicker">
             <div class="paidfor-meta">


### PR DESCRIPTION
## What does this change?
Remove the `[%TrackingId%]` from CAPI Multiple Paid For native ads.

## Why

This parameter is not provided via the native format in GAM - this causes an error when attempting to publish the template style since it expects a Tracking Id and none is provided.