### PR TITLE
Fix meta text for Events Multiple templates

### DIFF
--- a/src/_shared/js/events-multiple.js
+++ b/src/_shared/js/events-multiple.js
@@ -71,15 +71,16 @@ const boldTitle = title => {
 // Constructs the title part of the card: headline and media icon.
 function buildTitle(card, cardInfo, cardNumber) {
   let title = card.querySelector(".advert__title");
+  let meta = card.querySelector(".advert__meta");
   let metaText = OVERRIDES.metas[cardNumber];
 
-  let meta = metaText ? `<div class="advert__meta">${metaText}</div>` : "";
   let headline = OVERRIDES.headlines[cardNumber] || boldTitle(cardInfo.title);
   card.classList.add("advert--text");
 
   card.setAttribute("data-link-name", headline);
 
-  title.insertAdjacentHTML("beforeend", [headline, meta].join(" "));
+  title.insertAdjacentHTML("beforeend", headline);
+  meta.insertAdjacentHTML("beforeend", metaText || "");
 }
 
 function injectBranchLogo() {

--- a/src/events-multiple/web/index.html
+++ b/src/events-multiple/web/index.html
@@ -23,6 +23,7 @@
     <a class="blink advert advert--prominent-[%IsProminent%] advert--[%Tone%]" href="" data-link-name="" target="_top">
         <div class="advert__image-container"></div>
         <h2 class="blink__anchor advert__title"></h2>
+        <div class="advert__meta"></div>
         <span class="advert__more button button--small">
             [%CardClickthrough%]
             {{#svg}}arrow-right{{/svg}}


### PR DESCRIPTION
## What does this change?

Move the meta text associated with each card from a child of the title text to sibling. This has the effect of not applying header styling to the meta text.

## Why

Meta text shouldn't have the advert title styling applied. If this is desired the text can be included as part of the title from within Ad Manager.

## Images

### Before
![Screenshot 2021-09-29 at 10 09 35](https://user-images.githubusercontent.com/8000415/135253392-bccbf5bc-0a47-4241-bbb8-b5f963493657.png)

### After
![Screenshot 2021-09-29 at 10 44 45](https://user-images.githubusercontent.com/8000415/135253358-ab33f5e1-a40b-40d9-8319-fec7574539cf.png)


