### PR TITLE
fix: set branch to `main`

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -21,10 +21,7 @@
 		legacy: 'Deprecated',
 	};
 
-	/**
-	 * TODO: set to `main`
-	 */
-	const branch = 'svelte-kit';
+	const branch = 'main';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## What does this change?

Set the active branch to `main` so documentation can be linked to accurately.

## How to test

Check the deployment links are working.

## How can we measure success?

No link rot.

## Have we considered potential risks?

N/A