### PR TITLE
Consolidate plugins in eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,8 +2,8 @@ module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
 	extends: ['@guardian/eslint-config-typescript'],
-	plugins: ['svelte3', '@typescript-eslint'],
-	ignorePatterns: ['*.cjs', 'svelte.config.js'],
+	plugins: ['svelte3', '@typescript-eslint', 'import'],
+	ignorePatterns: ['*.cjs', 'svelte.config.js', 'legacy/**'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	settings: {
 		'svelte3/typescript': () => require('typescript'),
@@ -18,7 +18,6 @@ module.exports = {
 		sourceType: 'module',
 		ecmaVersion: 2020,
 	},
-	plugins: ['@typescript-eslint', 'import'],
 	env: {
 		browser: true,
 		es2017: true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
-    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
+    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
+    "lint:fix": "eslint --ignore-path .gitignore . --fix"
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.7.0",


### PR DESCRIPTION
## What does this change?

Consolidate plugins property in `.eslintrc.cjs` – there are currently two entries for this property, which causes ESLint to fail with the message:

> invalid: 'svelte3/svelte3' was not found

For convenience, I've also made the following changes:

- added a `lint:fix` script that automatically fixes lint errors detecting to ESLint, if possible
- ignored `legacy/` code from ESlint run – mainly because it finds so many errors, and fixing them seems lower priority right now. Happy to discuss!

## How to test

Run ESLint:

```sh
$ npm run lint
```

Observe that the error message no longer appears and ESLint run completes successfully – albeit with legitimate linting errors we can fix later.
