### PR TITLE
Upgrade sveltekit and vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
 				"@rollup/plugin-node-resolve": "^13.1.1",
 				"@rollup/plugin-typescript": "^8.3.0",
 				"@sveltejs/adapter-auto": "next",
-				"@sveltejs/adapter-static": "^1.0.0-next.26",
-				"@sveltejs/kit": "1.0.0-next.230",
+				"@sveltejs/adapter-static": "1.0.0-next.38",
+				"@sveltejs/kit": "1.0.0-next.394",
 				"@tsconfig/svelte": "^3.0.0",
 				"@types/marked": "^4.0.1",
 				"@types/rollup-plugin-css-only": "^3.1.0",
@@ -37,11 +37,11 @@
 				"rollup-plugin-terser": "^7.0.2",
 				"sass": "^1.47.0",
 				"svelte": "^3.49.0",
-				"svelte-check": "^2.2.12",
-				"svelte-preprocess": "^4.10.1",
+				"svelte-check": "^2.8.0",
+				"svelte-preprocess": "^4.10.7",
 				"tslib": "^2.3.1",
 				"typescript": "^4.7.4",
-				"vite": "^2.7.2"
+				"vite": "^3.0.3"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -447,6 +447,31 @@
 			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
 			"dev": true
 		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -609,9 +634,9 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
-			"version": "1.0.0-next.26",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.26.tgz",
-			"integrity": "sha512-LXR0HkPygZ+m9wJhFqbYWbJ0jquhgUK6vL/8AwnqbAZGGtQFloMpf49WOANk7MiLBeY6L97W5jPLSxHiDW3T0Q==",
+			"version": "1.0.0-next.38",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.38.tgz",
+			"integrity": "sha512-O1b264K62E3OrUnsFxMjKn3CUJF50fxGcW0rWk8fa5kjzskPsSyTxS3jnWNryFaVJ3oSUtx57m4qFW43S1910Q==",
 			"dev": true,
 			"dependencies": {
 				"tiny-glob": "^0.2.9"
@@ -627,45 +652,46 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.230",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.230.tgz",
-			"integrity": "sha512-97i5KK7oDqgzm8rSQTqXsscTt1ajkjlamidaxtADL183NiYWi1kqkOt+mskYU+RverGUuHTNl/8yg5p5ZEZm1A==",
+			"version": "1.0.0-next.394",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.394.tgz",
+			"integrity": "sha512-YfRNSKdbvihHFvmQodaMlChcyf9dfU36FwK8WYQF5jqEmiRajLBb/ooU6RqPA0Z6j5okJHDSYBwxW8TP+nc+gg==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-				"sade": "^1.7.4",
-				"vite": "^2.7.2"
+				"@sveltejs/vite-plugin-svelte": "^1.0.1",
+				"chokidar": "^3.5.3",
+				"sade": "^1.8.1"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": ">=14.13"
+				"node": ">=16.9"
 			},
 			"peerDependencies": {
-				"svelte": "^3.44.0"
+				"svelte": "^3.44.0",
+				"vite": "^3.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.32",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.32.tgz",
-			"integrity": "sha512-Lhf5BxVylosHIW6U2s6WDQA39ycd+bXivC8gHsXCJeLzxoHj7Pv7XAOk25xRSXT4wHg9DWFMBQh2DFU0DxHZ2g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
+			"integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
 			"dev": true,
 			"dependencies": {
-				"@rollup/pluginutils": "^4.1.1",
-				"debug": "^4.3.3",
-				"kleur": "^4.1.4",
-				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.7"
+				"@rollup/pluginutils": "^4.2.1",
+				"debug": "^4.3.4",
+				"deepmerge": "^4.2.2",
+				"kleur": "^4.1.5",
+				"magic-string": "^0.26.2",
+				"svelte-hmr": "^0.14.12"
 			},
 			"engines": {
-				"node": "^14.13.1 || >= 16"
+				"node": "^14.18.0 || >= 16"
 			},
 			"peerDependencies": {
 				"diff-match-patch": "^1.0.5",
 				"svelte": "^3.44.0",
-				"vite": "^2.7.0"
+				"vite": "^3.0.0"
 			},
 			"peerDependenciesMeta": {
 				"diff-match-patch": {
@@ -674,9 +700,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/@rollup/pluginutils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 			"dev": true,
 			"dependencies": {
 				"estree-walker": "^2.0.1",
@@ -684,6 +710,18 @@
 			},
 			"engines": {
 				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@tsconfig/svelte": {
@@ -1214,10 +1252,16 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -1515,6 +1559,22 @@
 				"esbuild-windows-arm64": "0.13.15"
 			}
 		},
+		"node_modules/esbuild-android-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.50.tgz",
+			"integrity": "sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/esbuild-android-arm64": {
 			"version": "0.13.15",
 			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
@@ -1657,6 +1717,38 @@
 			"os": [
 				"linux"
 			]
+		},
+		"node_modules/esbuild-linux-riscv64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.50.tgz",
+			"integrity": "sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild-linux-s390x": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.50.tgz",
+			"integrity": "sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/esbuild-netbsd-64": {
 			"version": "0.13.15",
@@ -3121,9 +3213,9 @@
 			}
 		},
 		"node_modules/kleur": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -3328,9 +3420,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -3601,21 +3693,27 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				}
+			],
 			"dependencies": {
-				"nanoid": "^3.1.30",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.1"
+				"source-map-js": "^1.0.2"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -3810,9 +3908,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.66.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.1.tgz",
-			"integrity": "sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==",
+			"version": "2.77.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
+			"integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -3948,15 +4046,15 @@
 			}
 		},
 		"node_modules/sade": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
 			"dev": true,
 			"dependencies": {
 				"mri": "^1.1.0"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=6"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -4157,9 +4255,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4325,18 +4423,17 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.12.tgz",
-			"integrity": "sha512-ryQSuZaZSOrhrJWU7dE/Gyq/xGwgjPEkur6GMjeNIjYH0BIDKId6YKXWI14CE2BZl7Ra5zrBDEc548kX6TcnlQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.8.0.tgz",
+			"integrity": "sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==",
 			"dev": true,
 			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.9",
 				"chokidar": "^3.4.1",
 				"fast-glob": "^3.2.7",
 				"import-fresh": "^3.2.1",
-				"minimist": "^1.2.5",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"source-map": "^0.7.3",
 				"svelte-preprocess": "^4.0.0",
 				"typescript": "*"
 			},
@@ -4348,18 +4445,21 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
-			"integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.12.tgz",
+			"integrity": "sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==",
 			"dev": true,
+			"engines": {
+				"node": "^12.20 || ^14.13.1 || >= 16"
+			},
 			"peerDependencies": {
 				"svelte": ">=3.19.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz",
-			"integrity": "sha512-NSNloaylf+o9UeyUR2KvpdxrAyMdHl3U7rMnoP06/sG0iwJvlUM4TpMno13RaNqovh4AAoGsx1jeYcIyuGUXMw==",
+			"version": "4.10.7",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
+			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -4376,15 +4476,15 @@
 			"peerDependencies": {
 				"@babel/core": "^7.10.2",
 				"coffeescript": "^2.5.1",
-				"less": "^3.11.3",
+				"less": "^3.11.3 || ^4.0.0",
 				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0",
+				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
 				"pug": "^3.0.0",
 				"sass": "^1.26.8",
-				"stylus": "^0.54.7",
+				"stylus": "^0.55.0",
 				"sugarss": "^2.0.0",
 				"svelte": "^3.23.0",
-				"typescript": "^4.5.2"
+				"typescript": "^3.9.5 || ^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -4618,21 +4718,21 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.2.tgz",
-			"integrity": "sha512-wMffVVdKZRZP/HwW3yttKL8X+IJePz7bUcnGm0vqljffpVwHpjWC3duZtJQHAGvy+wrTjmwU7vkULpZ1dVXY6w==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.3.tgz",
+			"integrity": "sha512-sDIpIcl3mv1NUaSzZwiXGEy1ZoWwwC2vkxUHY6yiDacR6zf//ZFuBJrozO62gedpE43pmxnLATNR5IYUdAEkMQ==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.13.12",
-				"postcss": "^8.3.11",
-				"resolve": "^1.20.0",
-				"rollup": "^2.59.0"
+				"esbuild": "^0.14.47",
+				"postcss": "^8.4.14",
+				"resolve": "^1.22.1",
+				"rollup": "^2.75.6"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": ">=12.2.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -4640,7 +4740,8 @@
 			"peerDependencies": {
 				"less": "*",
 				"sass": "*",
-				"stylus": "*"
+				"stylus": "*",
+				"terser": "^5.4.0"
 			},
 			"peerDependenciesMeta": {
 				"less": {
@@ -4651,7 +4752,317 @@
 				},
 				"stylus": {
 					"optional": true
+				},
+				"terser": {
+					"optional": true
 				}
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.50.tgz",
+			"integrity": "sha512-SbC3k35Ih2IC6trhbMYW7hYeGdjPKf9atTKwBUHqMCYFZZ9z8zhuvfnZihsnJypl74FjiAKjBRqFkBkAd0rS/w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"esbuild-android-64": "0.14.50",
+				"esbuild-android-arm64": "0.14.50",
+				"esbuild-darwin-64": "0.14.50",
+				"esbuild-darwin-arm64": "0.14.50",
+				"esbuild-freebsd-64": "0.14.50",
+				"esbuild-freebsd-arm64": "0.14.50",
+				"esbuild-linux-32": "0.14.50",
+				"esbuild-linux-64": "0.14.50",
+				"esbuild-linux-arm": "0.14.50",
+				"esbuild-linux-arm64": "0.14.50",
+				"esbuild-linux-mips64le": "0.14.50",
+				"esbuild-linux-ppc64le": "0.14.50",
+				"esbuild-linux-riscv64": "0.14.50",
+				"esbuild-linux-s390x": "0.14.50",
+				"esbuild-netbsd-64": "0.14.50",
+				"esbuild-openbsd-64": "0.14.50",
+				"esbuild-sunos-64": "0.14.50",
+				"esbuild-windows-32": "0.14.50",
+				"esbuild-windows-64": "0.14.50",
+				"esbuild-windows-arm64": "0.14.50"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-android-arm64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.50.tgz",
+			"integrity": "sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.50.tgz",
+			"integrity": "sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-arm64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.50.tgz",
+			"integrity": "sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.50.tgz",
+			"integrity": "sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-arm64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.50.tgz",
+			"integrity": "sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-32": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.50.tgz",
+			"integrity": "sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.50.tgz",
+			"integrity": "sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.50.tgz",
+			"integrity": "sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.50.tgz",
+			"integrity": "sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-mips64le": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.50.tgz",
+			"integrity": "sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-ppc64le": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.50.tgz",
+			"integrity": "sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-netbsd-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.50.tgz",
+			"integrity": "sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-openbsd-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.50.tgz",
+			"integrity": "sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-sunos-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.50.tgz",
+			"integrity": "sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-32": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.50.tgz",
+			"integrity": "sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.50.tgz",
+			"integrity": "sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-arm64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.50.tgz",
+			"integrity": "sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/which": {
@@ -4980,6 +5391,28 @@
 			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
 			"dev": true
 		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5103,9 +5536,9 @@
 			}
 		},
 		"@sveltejs/adapter-static": {
-			"version": "1.0.0-next.26",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.26.tgz",
-			"integrity": "sha512-LXR0HkPygZ+m9wJhFqbYWbJ0jquhgUK6vL/8AwnqbAZGGtQFloMpf49WOANk7MiLBeY6L97W5jPLSxHiDW3T0Q==",
+			"version": "1.0.0-next.38",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.38.tgz",
+			"integrity": "sha512-O1b264K62E3OrUnsFxMjKn3CUJF50fxGcW0rWk8fa5kjzskPsSyTxS3jnWNryFaVJ3oSUtx57m4qFW43S1910Q==",
 			"dev": true,
 			"requires": {
 				"tiny-glob": "^0.2.9"
@@ -5121,38 +5554,47 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.230",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.230.tgz",
-			"integrity": "sha512-97i5KK7oDqgzm8rSQTqXsscTt1ajkjlamidaxtADL183NiYWi1kqkOt+mskYU+RverGUuHTNl/8yg5p5ZEZm1A==",
+			"version": "1.0.0-next.394",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.394.tgz",
+			"integrity": "sha512-YfRNSKdbvihHFvmQodaMlChcyf9dfU36FwK8WYQF5jqEmiRajLBb/ooU6RqPA0Z6j5okJHDSYBwxW8TP+nc+gg==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
-				"sade": "^1.7.4",
-				"vite": "^2.7.2"
+				"@sveltejs/vite-plugin-svelte": "^1.0.1",
+				"chokidar": "^3.5.3",
+				"sade": "^1.8.1"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.32",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.32.tgz",
-			"integrity": "sha512-Lhf5BxVylosHIW6U2s6WDQA39ycd+bXivC8gHsXCJeLzxoHj7Pv7XAOk25xRSXT4wHg9DWFMBQh2DFU0DxHZ2g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
+			"integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^4.1.1",
-				"debug": "^4.3.3",
-				"kleur": "^4.1.4",
-				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.7"
+				"@rollup/pluginutils": "^4.2.1",
+				"debug": "^4.3.4",
+				"deepmerge": "^4.2.2",
+				"kleur": "^4.1.5",
+				"magic-string": "^0.26.2",
+				"svelte-hmr": "^0.14.12"
 			},
 			"dependencies": {
 				"@rollup/pluginutils": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
-					"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 					"dev": true,
 					"requires": {
 						"estree-walker": "^2.0.1",
 						"picomatch": "^2.2.2"
+					}
+				},
+				"magic-string": {
+					"version": "0.26.2",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+					"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+					"dev": true,
+					"requires": {
+						"sourcemap-codec": "^1.4.8"
 					}
 				}
 			}
@@ -5525,9 +5967,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
@@ -5761,6 +6203,13 @@
 				"esbuild-windows-arm64": "0.13.15"
 			}
 		},
+		"esbuild-android-64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.50.tgz",
+			"integrity": "sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==",
+			"dev": true,
+			"optional": true
+		},
 		"esbuild-android-arm64": {
 			"version": "0.13.15",
 			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
@@ -5835,6 +6284,20 @@
 			"version": "0.13.15",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
 			"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-riscv64": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.50.tgz",
+			"integrity": "sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-s390x": {
+			"version": "0.14.50",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.50.tgz",
+			"integrity": "sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==",
 			"dev": true,
 			"optional": true
 		},
@@ -6904,9 +7367,9 @@
 			}
 		},
 		"kleur": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"dev": true
 		},
 		"levn": {
@@ -7062,9 +7525,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.30",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-			"integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -7257,14 +7720,14 @@
 			}
 		},
 		"postcss": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+			"version": "8.4.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.1.30",
+				"nanoid": "^3.3.4",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.1"
+				"source-map-js": "^1.0.2"
 			}
 		},
 		"prelude-ls": {
@@ -7387,9 +7850,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.66.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.1.tgz",
-			"integrity": "sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==",
+			"version": "2.77.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
+			"integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -7478,9 +7941,9 @@
 			}
 		},
 		"sade": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
 			"dev": true,
 			"requires": {
 				"mri": "^1.1.0"
@@ -7622,9 +8085,9 @@
 			"dev": true
 		},
 		"source-map-js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
 		},
 		"source-map-support": {
@@ -7749,33 +8212,32 @@
 			"dev": true
 		},
 		"svelte-check": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.2.12.tgz",
-			"integrity": "sha512-ryQSuZaZSOrhrJWU7dE/Gyq/xGwgjPEkur6GMjeNIjYH0BIDKId6YKXWI14CE2BZl7Ra5zrBDEc548kX6TcnlQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.8.0.tgz",
+			"integrity": "sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==",
 			"dev": true,
 			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.9",
 				"chokidar": "^3.4.1",
 				"fast-glob": "^3.2.7",
 				"import-fresh": "^3.2.1",
-				"minimist": "^1.2.5",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"source-map": "^0.7.3",
 				"svelte-preprocess": "^4.0.0",
 				"typescript": "*"
 			}
 		},
 		"svelte-hmr": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
-			"integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
+			"version": "0.14.12",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.12.tgz",
+			"integrity": "sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==",
 			"dev": true,
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz",
-			"integrity": "sha512-NSNloaylf+o9UeyUR2KvpdxrAyMdHl3U7rMnoP06/sG0iwJvlUM4TpMno13RaNqovh4AAoGsx1jeYcIyuGUXMw==",
+			"version": "4.10.7",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
+			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
 			"dev": true,
 			"requires": {
 				"@types/pug": "^2.0.4",
@@ -7940,16 +8402,165 @@
 			"dev": true
 		},
 		"vite": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.2.tgz",
-			"integrity": "sha512-wMffVVdKZRZP/HwW3yttKL8X+IJePz7bUcnGm0vqljffpVwHpjWC3duZtJQHAGvy+wrTjmwU7vkULpZ1dVXY6w==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.3.tgz",
+			"integrity": "sha512-sDIpIcl3mv1NUaSzZwiXGEy1ZoWwwC2vkxUHY6yiDacR6zf//ZFuBJrozO62gedpE43pmxnLATNR5IYUdAEkMQ==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.13.12",
+				"esbuild": "^0.14.47",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.3.11",
-				"resolve": "^1.20.0",
-				"rollup": "^2.59.0"
+				"postcss": "^8.4.14",
+				"resolve": "^1.22.1",
+				"rollup": "^2.75.6"
+			},
+			"dependencies": {
+				"esbuild": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.50.tgz",
+					"integrity": "sha512-SbC3k35Ih2IC6trhbMYW7hYeGdjPKf9atTKwBUHqMCYFZZ9z8zhuvfnZihsnJypl74FjiAKjBRqFkBkAd0rS/w==",
+					"dev": true,
+					"requires": {
+						"esbuild-android-64": "0.14.50",
+						"esbuild-android-arm64": "0.14.50",
+						"esbuild-darwin-64": "0.14.50",
+						"esbuild-darwin-arm64": "0.14.50",
+						"esbuild-freebsd-64": "0.14.50",
+						"esbuild-freebsd-arm64": "0.14.50",
+						"esbuild-linux-32": "0.14.50",
+						"esbuild-linux-64": "0.14.50",
+						"esbuild-linux-arm": "0.14.50",
+						"esbuild-linux-arm64": "0.14.50",
+						"esbuild-linux-mips64le": "0.14.50",
+						"esbuild-linux-ppc64le": "0.14.50",
+						"esbuild-linux-riscv64": "0.14.50",
+						"esbuild-linux-s390x": "0.14.50",
+						"esbuild-netbsd-64": "0.14.50",
+						"esbuild-openbsd-64": "0.14.50",
+						"esbuild-sunos-64": "0.14.50",
+						"esbuild-windows-32": "0.14.50",
+						"esbuild-windows-64": "0.14.50",
+						"esbuild-windows-arm64": "0.14.50"
+					}
+				},
+				"esbuild-android-arm64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.50.tgz",
+					"integrity": "sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.50.tgz",
+					"integrity": "sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-arm64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.50.tgz",
+					"integrity": "sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.50.tgz",
+					"integrity": "sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-arm64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.50.tgz",
+					"integrity": "sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-32": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.50.tgz",
+					"integrity": "sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.50.tgz",
+					"integrity": "sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.50.tgz",
+					"integrity": "sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.50.tgz",
+					"integrity": "sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-mips64le": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.50.tgz",
+					"integrity": "sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-ppc64le": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.50.tgz",
+					"integrity": "sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-netbsd-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.50.tgz",
+					"integrity": "sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-openbsd-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.50.tgz",
+					"integrity": "sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-sunos-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.50.tgz",
+					"integrity": "sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-32": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.50.tgz",
+					"integrity": "sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.50.tgz",
+					"integrity": "sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-arm64": {
+					"version": "0.14.50",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.50.tgz",
+					"integrity": "sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"preview": "vite preview",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
+		"lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
 		"lint:fix": "prettier --write --plugin-search-dir=. . && eslint --ignore-path .gitignore . --fix"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
 	"name": "@guardian/commercial-templates-builder",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "svelte-kit dev --port 7777",
-		"build": "svelte-kit build && touch build/.nojekyll && rsync -avz build/commercial-templates/ build --remove-source-files",
+		"dev": "NODE_ENV=development vite dev --port 7777",
+		"build": "vite build && touch build/.nojekyll && rsync -avz build/commercial-templates/ build --remove-source-files",
 		"publish": "npx gh-pages --dist build --dotfiles",
 		"deploy": "npm run build && npm run publish",
 		"package": "svelte-kit package",
-		"preview": "svelte-kit preview",
+		"preview": "vite preview",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
+		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
 		"lint:fix": "prettier --write --plugin-search-dir=. . && eslint --ignore-path .gitignore . --fix"
 	},
 	"devDependencies": {
@@ -20,8 +20,8 @@
 		"@rollup/plugin-node-resolve": "^13.1.1",
 		"@rollup/plugin-typescript": "^8.3.0",
 		"@sveltejs/adapter-auto": "next",
-		"@sveltejs/adapter-static": "^1.0.0-next.26",
-		"@sveltejs/kit": "1.0.0-next.230",
+		"@sveltejs/adapter-static": "1.0.0-next.38",
+		"@sveltejs/kit": "1.0.0-next.394",
 		"@tsconfig/svelte": "^3.0.0",
 		"@types/marked": "^4.0.1",
 		"@types/rollup-plugin-css-only": "^3.1.0",
@@ -43,11 +43,11 @@
 		"rollup-plugin-terser": "^7.0.2",
 		"sass": "^1.47.0",
 		"svelte": "^3.49.0",
-		"svelte-check": "^2.2.12",
-		"svelte-preprocess": "^4.10.1",
+		"svelte-check": "^2.8.0",
+		"svelte-preprocess": "^4.10.7",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",
-		"vite": "^2.7.2"
+		"vite": "^3.0.3"
 	},
 	"type": "module"
 }

--- a/src/app.html
+++ b/src/app.html
@@ -7,9 +7,9 @@
 			content="Guardian Bespoke Commercial Templates"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/routes/csr/[template].json.ts
+++ b/src/routes/csr/[template].json.ts
@@ -7,7 +7,7 @@ import { getProps } from '$lib/svelte';
 
 const github = 'https://github.com/guardian/commercial-templates/blob';
 
-export const get: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params }) => {
 	const template = params.template ?? 'unknown';
 
 	const dir = `src/templates/csr/${template}`;

--- a/src/routes/ssr/[template].json.ts
+++ b/src/routes/ssr/[template].json.ts
@@ -40,7 +40,7 @@ const prerender = (code: string): Output => {
 const isChunk = (output: OutputChunk | OutputAsset): output is OutputChunk =>
 	output.type === 'chunk';
 
-export const get: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params }) => {
 	const template = params.template ?? 'unknown';
 
 	const dir = `src/templates/ssr/${template}`;

--- a/src/routes/templates.json.ts
+++ b/src/routes/templates.json.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit/types';
 
 export type Templates = Record<'csr' | 'ssr' | 'legacy', string[]>;
 
-export const get: RequestHandler = async () => {
+export const GET: RequestHandler = async () => {
 	const csr = await readdir('src/templates/csr');
 	const ssr = await readdir('src/templates/ssr');
 	const legacy = (await readdir('legacy/src')).filter(

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,6 +1,5 @@
 import adapter from '@sveltejs/adapter-static';
 import preprocess from 'svelte-preprocess';
-import { defineConfig } from 'vite';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -13,8 +12,9 @@ const config = {
 	kit: {
 		adapter: adapter(),
 
-		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte',
+		prerender: {
+			default: true,
+		},
 
 		paths: {
 			base: isDev ? undefined : '/commercial-templates',
@@ -22,42 +22,6 @@ const config = {
 
 		// Github pages really likes its trailing slashes!
 		trailingSlash: isDev ? 'never' : 'always',
-
-		vite: defineConfig({
-			plugins: [
-				{
-					name: 'watch-templates',
-					configureServer(server) {
-						server.watcher.add('/src/templates');
-					},
-					handleHotUpdate(ctx) {
-						const TEMPLATE =
-							/\/templates\/([\w-\/]+?)\/[\w-]+?\.(svelte|js|ts|md|css|json)$/i;
-						const matches = TEMPLATE.exec(ctx.file);
-
-						if (!matches) return ctx.modules;
-
-						console.warn(
-							`Template ${matches[1]} changed`,
-							'sending template-update event',
-						);
-
-						/** @type {import('./src/lib/reload').Data} */
-						const data = {
-							id: matches[1],
-						};
-
-						ctx.server.ws.send({
-							type: 'custom',
-							event: 'template-update',
-							data,
-						});
-
-						return [];
-					},
-				},
-			],
-		}),
 	},
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+
+/** @type {import('vite').UserConfig} */
+const config = {
+	plugins: [sveltekit()],
+};
+
+export default config;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,40 @@ import { sveltekit } from '@sveltejs/kit/vite';
 
 /** @type {import('vite').UserConfig} */
 const config = {
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit(),
+		{
+			name: 'watch-templates',
+			configureServer(server) {
+				server.watcher.add('/src/templates');
+			},
+			handleHotUpdate(ctx) {
+				const TEMPLATE =
+					/\/templates\/([\w-\/]+?)\/[\w-]+?\.(svelte|js|ts|md|css|json)$/i;
+				const matches = TEMPLATE.exec(ctx.file);
+
+				if (!matches) return ctx.modules;
+
+				console.warn(
+					`Template ${matches[1]} changed`,
+					'sending template-update event',
+				);
+
+				/** @type {import('./src/lib/reload').Data} */
+				const data = {
+					id: matches[1],
+				};
+
+				ctx.server.ws.send({
+					type: 'custom',
+					event: 'template-update',
+					data,
+				});
+
+				return [];
+			},
+		},
+	],
 };
 
 export default config;


### PR DESCRIPTION
## What does this change?

- upgrades to the latest versions of `@sveltejs/kit` and `vite`. This exposes vite to the developer, as opposed to hiding it behind the svelte-kit CLI.

## How to test

The following scripts still work:

```sh
$ npm run dev
$ npm run build
$ npm run preview
```