### PR TITLE
Remove rsync dir jiggling from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "NODE_ENV=development vite dev --port 7777",
-		"build": "vite build && touch build/.nojekyll && rsync -avz build/commercial-templates/ build --remove-source-files",
+		"build": "vite build && touch build/.nojekyll",
 		"publish": "npx gh-pages --dist build --dotfiles",
 		"deploy": "npm run build && npm run publish",
 		"package": "svelte-kit package",


### PR DESCRIPTION
## What does this change?

Removes the `rsync` directory jiggling part of the build script as it no longer appears to be necessary.

## How to test

Deploy Svelte-kit preview via

```sh
$ npm run deploy
```

Open:

https://guardian.github.io/commercial-templates/