### PR TITLE
pass interscroller identifier to getIframeId

### DIFF
--- a/legacy/src/interscroller/web/index.js
+++ b/legacy/src/interscroller/web/index.js
@@ -27,6 +27,6 @@ const updateBackground = () => {
     });
 };
 
-getIframeId()
+getIframeId('interscroller')
 .then(() => {onViewport(once(updateBackground));})
 .then(() => resizeIframeHeight('85vh'));


### PR DESCRIPTION
## What does this change?
Pass an identifier to `getIframeId` so that frontend will add an appropriate classname.

We need this class to target the interscroller ads with specific css, an example added here https://github.com/guardian/dotcom-rendering/pull/5527