### PR TITLE
Add Svelte migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ You can see the current templates on [guardian.github.io/commercial-templates](h
 This project is a rewrite and work-in-progress. Legacy templates can still be
 found in the [`/legacy` folder](/legacy)
 
-- [More information on creating Svelte templates](/docs/svelte-template-authoring.md)
-- [More information on migrating legacy templates](/docs/legacy-to-svelte-migration.md)
+- [Creating Svelte templates](/docs/svelte-template-authoring.md)
+- [Migrating legacy templates to Svelte](/docs/legacy-to-svelte-migration.md)
 
 ## Developing Locally
 
@@ -31,9 +31,9 @@ yarn dev --open
 ```
 
 When you change templates or shared components, the components will
-reload automatically. [Read more about Svelte templates in `src/templates/`][t]
+reload automatically. [Read more about Svelte templates in `docs/`][t]
 
-[t]: src/templates/README.md
+[t]: docs/svelte-template-authoring.md
 
 ## Deploying to Github Pages
 

--- a/docs/legacy-to-svelte-migration.md
+++ b/docs/legacy-to-svelte-migration.md
@@ -6,6 +6,28 @@ The legacy templates typically start with a call to `getIframeId` which is depre
 
 They'll then often use some shared legacy functionality like `resizeIframeHeight` and `sendMessage`, these wrap a post message to the parent frame in additional boilerplate that's probably no longer needed and in many cases can be replaced with a simple [`post`](/src/lib/messenger.ts).
 
+## Automation
+
+Svelte migration can be partially automated by running:
+
+```sh
+$ yarn migrate <template-name>
+```
+
+For example:
+
+```sh
+$ yarn migrate glabs-native-traffic-driver
+```
+
+This does the following:
+
+- Creates a Svelte template populated with the HTML and SCSS of the legacy template
+- Creates an index.ts, copied from the index.js of the legacy template
+- Creates a test.json, copied from the legacy template
+
+The index.ts will need to manually updated to account for deprecations to legacy patterns – see below.
+
 ## Example - Interscroller
 
 ### Legacy
@@ -93,7 +115,7 @@ index.scss
 - Combine js, html and css into a `.svelte` file
 - The `getIframeId` can be removed
 - `sendMessage` can be replaced with `post`
-- `resizeIframeHeight` can be replaced with post
+- `resizeIframeHeight` can be replaced with `post`
 - `onViewport` this runs the callback whenever the parent viewport is resized, but the result isn't used so can be removed
 
 So we're left with:

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
 		"deploy": "yarn build && yarn publish",
 		"package": "svelte-kit package",
 		"preview": "vite preview",
+		"tsc": "tsc --noEmit",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
-		"lint:fix": "prettier --write --plugin-search-dir=. . && eslint --ignore-path .gitignore . --fix"
+		"lint:fix": "prettier --write --plugin-search-dir=. . && eslint --ignore-path .gitignore . --fix",
+		"migrate": "ts-node-esm ./scripts/migrate-templates"
 	},
 	"devDependencies": {
 		"@guardian/eslint-config-typescript": "^1.0.2",
@@ -25,6 +27,8 @@
 		"@sveltejs/kit": "1.0.0-next.394",
 		"@tsconfig/svelte": "^3.0.0",
 		"@types/marked": "^4.0.1",
+		"@types/minimist": "^1.2.2",
+		"@types/mkdirp": "^1.0.2",
 		"@types/rollup-plugin-css-only": "^3.1.0",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
 		"@typescript-eslint/parser": "^5.30.7",
@@ -36,6 +40,8 @@
 		"gh-pages": "^3.2.3",
 		"isomorphic-git": "^1.10.2",
 		"marked": "^4.0.10",
+		"minimist": "^1.2.6",
+		"mkdirp": "^1.0.4",
 		"prettier": "2.7.1",
 		"prettier-plugin-svelte": "^2.7.0",
 		"rollup": "^2.66.1",
@@ -46,6 +52,7 @@
 		"svelte": "^3.49.0",
 		"svelte-check": "^2.8.0",
 		"svelte-preprocess": "^4.10.7",
+		"ts-node": "^10.9.1",
 		"tslib": "^2.3.1",
 		"typescript": "^4.7.4",
 		"vite": "^3.0.3"

--- a/scripts/migrate-templates.ts
+++ b/scripts/migrate-templates.ts
@@ -1,0 +1,80 @@
+import { existsSync, promises } from 'fs';
+import path from 'path';
+import minimist from 'minimist';
+import mkdirp from 'mkdirp';
+
+const argv = minimist(process.argv.slice(2));
+const { writeFile, readFile, rm, copyFile } = promises;
+const populateSvelteTemplate = ({
+	html,
+	scss,
+}: {
+	html: string;
+	scss: string;
+}) => `
+<!-- https://polyfill.io/v3/polyfill.min.js?features=default -->
+<script lang="ts">
+</script>
+
+${html}
+
+<style lang="scss">
+${scss}
+</style>
+`;
+const migrationTips = `
+/**
+ * commercial-templates Svelte migration tips
+ * ==============
+ *
+ * Congratulations on choosing to migrate this template to Svelte! Some of the
+ * patterns used in the legacy template have been deprecated or simplified. Here
+ * are some tips to help you migrate.
+ *
+ * Please delete this comment when you have finished migrating this file.
+ *
+ * * \`getIframeId\` can be removed
+ * * messages such as \`sendMessage\` can be replaced by calls to \`post\`
+ */
+`;
+
+void (async () => {
+	const templateName = argv._[0];
+
+	if (!templateName) {
+		console.log(`Please pass a template name to the migrate script
+usage: yarn migrate glabs-bative-traffic-driver`);
+		process.exit(-1);
+	}
+	if (!existsSync(path.resolve('legacy', 'src', templateName))) {
+		console.log(
+			`Template "${templateName}" not found. Please ensure legacy/src/${templateName}/ exists and try again`,
+		);
+		process.exit(-1);
+	}
+
+	// read legacy stuff
+	const legacyDir = path.resolve('legacy', 'src', templateName);
+	const legacyTestJsonFile = path.resolve(legacyDir, 'test.json');
+	const legacyHtmlFile = path.resolve(legacyDir, 'web', 'index.html');
+	const legacyScssFile = path.resolve(legacyDir, 'web', 'index.scss');
+	const legacyJsFile = path.resolve(legacyDir, 'web', 'index.js');
+	const html = await readFile(legacyHtmlFile, 'utf8');
+	const scss = await readFile(legacyScssFile, 'utf8');
+	const js = await readFile(legacyJsFile, 'utf8');
+
+	// write new stuff
+	const newDir = path.resolve('src', 'templates', 'ssr', templateName);
+	try {
+		await rm(newDir, { recursive: true });
+	} catch (e) {
+		// directory probably didn't exist
+	}
+	await mkdirp(newDir);
+	await copyFile(legacyTestJsonFile, path.resolve(newDir, 'test.json'));
+	await writeFile(path.resolve(newDir, 'index.ts'), `${migrationTips}${js}`);
+	await writeFile(
+		path.resolve(newDir, 'index.svelte'),
+		populateSvelteTemplate({ html, scss }),
+	);
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,11 @@
 			"$app/*": ["node_modules/@sveltejs/kit/types"]
 		}
 	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
+	"include": [
+		"src/**/*.d.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte",
+		"scripts"
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
@@ -114,6 +121,14 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -267,6 +282,26 @@
     magic-string "^0.26.2"
     svelte-hmr "^0.14.12"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
 "@tsconfig/svelte@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-3.0.0.tgz#b06e059209f04c414de0069f2f0e2796d979fc6f"
@@ -291,6 +326,18 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.1.tgz#d588a7bbc4d6551c5e75249bc106ffda96ae33c5"
   integrity sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==
+
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/mkdirp@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
+  integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node@*":
   version "16.11.12"
@@ -489,7 +536,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.5.0, acorn@^8.7.1:
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -530,6 +582,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -722,6 +779,11 @@ crc-32@^1.2.0:
     exit-on-epipe "~1.0.1"
     printj "~1.1.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -790,6 +852,11 @@ diff3@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/diff3/-/diff3-0.0.3.tgz#d4e5c3a4cdf4e5fe1211ab42e693fcb4321580fc"
   integrity sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1907,6 +1974,11 @@ make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 marked@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
@@ -1949,7 +2021,7 @@ minimatch@^3.0.4, minimatch@^3.1.2:
 
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minimisted@^2.0.0:
@@ -1965,6 +2037,11 @@ mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mri@^1.1.0:
   version "1.2.0"
@@ -2638,6 +2715,25 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -2709,6 +2805,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -2758,3 +2859,8 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
## What does this change?

Add a script that partially automates the migration of commercial-templates to Svelte. 

This PR represents a first pass at this script, to see if there's enough value in it.

```sh
$ yarn migrate glabs-native-traffic-driver
```

The HTML, SCSS and test.json is fully automated. JS is copied from `legacy` to the Svelte template's directory. However devs are still required to make manual changes to the JS.

https://user-images.githubusercontent.com/5931528/195858867-a3c65b62-6f6b-4dfd-a47f-8613b2366206.mov


## What isn't this doing?

- ❌ The JavaScript that is migrated will not run: it requires devs to make manual changes. These changes are partially documented in [docs/legacy-to-svelte-migration.md](https://github.com/guardian/commercial-templates/blob/main/docs/legacy-to-svelte-migration.md). I started to use the codemod tool [jscodeshift](https://github.com/facebook/jscodeshift) to transform legacy code into modern code but so many changes would be needed, it felt too big a task. The branch [`sa-jscodeshift`](https://github.com/guardian/commercial-templates/compare/svelte-migration-script...sa-jscodeshift) has my attempt.
- ❌ The `app` and `amp` templates are not migrated – only `web` is currently supported
- ❌ JavaScript is not added to the Svelte template. It is created in `index.ts`. This makes it easier to isolate the manual work that a dev needs to complete.