### PR TITLE
Update background colour to match DCR palette

### DIFF
--- a/legacy/src/_shared/scss/_adverts.scss
+++ b/legacy/src/_shared/scss/_adverts.scss
@@ -270,7 +270,7 @@
             }
         }
 
-                
+
         @include mq(leftCol) {
             padding: $gs-baseline 0;
         }
@@ -574,7 +574,7 @@
 
 /* Theming */
 .adverts--legacy {
-    background: #eaeaea;
+    background: #ededed;
 
     > .adverts__header .button {
         color: #000000;

--- a/legacy/src/_shared/scss/_hosted.scss
+++ b/legacy/src/_shared/scss/_hosted.scss
@@ -5,7 +5,7 @@ $phablet: 660px;
 .creative--hosted {
     font-family: $f-sans-serif-text;
     min-height: 100px;
-    background: #e9e9e9;
+    background: #ededed;
 
     @include mq(tablet) {
         background: none;
@@ -17,7 +17,7 @@ $phablet: 660px;
     padding: 6px 0 24px;
     border-top: 1px solid;
     margin: 0 auto;
-    background: #e9e9e9;
+    background: #ededed;
 
     @include mq($until: mobileLandscape) {
         margin-left: 10px;


### PR DESCRIPTION
## What does this change?

Update to the background colour of the merchandising slots to be consistent with the DCR palette. This should eliminate the colour difference between div and merchandising slots currently visible on articles rendered by DCR.