### PR TITLE
Fix capi single paidfor logos smaller than 200px stretching

### DIFF
--- a/legacy/src/capi-single-paidfor/web/index.scss
+++ b/legacy/src/capi-single-paidfor/web/index.scss
@@ -45,7 +45,8 @@
     }
 
     .badge__logo {
-      width: 200px;
+      display: block;
+      max-width: 200px;
       margin-left: 0;
     }
   }


### PR DESCRIPTION
previously logos were forced to 200px wide, and max height of 60px, causing a stretch with narrower logos.

## Before
![image (3)](https://user-images.githubusercontent.com/1731150/205948177-e0d9bdcc-8720-4f68-aa35-5bfb7de2cd1e.png)

## After
![Screenshot 2022-12-06 at 14 37 53](https://user-images.githubusercontent.com/1731150/205948258-18e1c384-09c2-42de-9b69-1e04f9284606.png)
