### PR TITLE
Remove trailing '/' from kicker

### DIFF
--- a/legacy/src/_shared/js/capi-multiple.js
+++ b/legacy/src/_shared/js/capi-multiple.js
@@ -33,7 +33,7 @@ function buildTitle (card, cardInfo, cardNumber) {
     let title = card.querySelector('.advert__title');
     let kickerText = OVERRIDES.kickers[cardNumber];
 
-    let kicker = kickerText ? `<span class="advert__kicker">${kickerText}</span>` : '';
+    let kicker = kickerText ? `<span class="advert__kicker">${kickerText}</span><br />` : '';
     let icon = '';
     let headline = OVERRIDES.headlines[cardNumber] || cardInfo.articleHeadline;
 

--- a/legacy/src/_shared/scss/_adverts-capi.scss
+++ b/legacy/src/_shared/scss/_adverts-capi.scss
@@ -231,8 +231,7 @@
             fill: $paid-article-icon;
         }
 
-        .advert__kicker,
-        .advert__kicker::after {
+        .advert__kicker {
             color: $paid-card-kicker;
         }
     }
@@ -295,17 +294,4 @@
         display: none;
     }
 
-}
-
-.advert__kicker {
-    &:after {
-        content: '/';
-        display: inline-block;
-        margin-left: .2em;
-        color: mix($neutral-1, #ffffff, 20%);
-    }
-
-    &:hover:after {
-        text-decoration: none;
-    }
 }

--- a/legacy/src/capi-multiple-paidfor/app/app-capi-multiple.js
+++ b/legacy/src/capi-multiple-paidfor/app/app-capi-multiple.js
@@ -31,7 +31,7 @@ function buildTitle (card, cardInfo, cardNumber) {
     let title = card.querySelector('.advert__title');
     let kickerText = OVERRIDES.kickers[cardNumber];
 
-    let kicker = kickerText ? `<span class="advert__kicker">${kickerText}</span>` : '';
+    let kicker = kickerText ? `<span class="advert__kicker">${kickerText}</span><br />` : '';
     let icon = '';
     let headline = OVERRIDES.headlines[cardNumber] || cardInfo.articleHeadline;
 


### PR DESCRIPTION
Remove the trailing `/` added to kickers via CSS, and add a line-break after the kicker (when a kicker is rendered).

This brings the kicker styling into line with the new designs for web -- see [DCR Issue #6943](https://github.com/guardian/dotcom-rendering/issues/6943)

Co-authored-by: Anna Beddow <anna.beddow@guardian.co.uk>
Co-authored-by: Jake Lee Kennedy <jake.kennedy@guardian.co.uk>## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

We have tested this locally using the `preview` app. The commercial team may want to try a test build in GAM before deploying.

**nb.** We may want to hold off on deploying to PROD until the corresponding Frontend/DCR changes have been deployed.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
