### PR TITLE
Fix fabric margins on Firefox

### DIFF
--- a/legacy/src/_shared/scss/_adverts-fabric.scss
+++ b/legacy/src/_shared/scss/_adverts-fabric.scss
@@ -1,0 +1,3 @@
+body {
+	margin: 0;
+}

--- a/legacy/src/fabric-custom/web/index.scss
+++ b/legacy/src/fabric-custom/web/index.scss
@@ -1,1 +1,2 @@
 @import '_core';
+@import '_adverts-fabric';

--- a/legacy/src/fabric-video/web/index.scss
+++ b/legacy/src/fabric-video/web/index.scss
@@ -1,4 +1,5 @@
 @import '_core';
+@import '_adverts-fabric';
 
 .creative--fabric-video {
     margin: auto;

--- a/legacy/src/fabric/web/index.scss
+++ b/legacy/src/fabric/web/index.scss
@@ -1,4 +1,5 @@
 @import '_core';
+@import '_adverts-fabric';
 
 .creative--fabric {
     &,


### PR DESCRIPTION
## What does this change?

On Firefox, the default browser margin means that fabric ads display with space between the ad label and top of the page (see image), which they shouldn't. This PR sets the margin to zero to ensure that fabric ads display as expected on Firefox.

![Screenshot 2023-02-28 at 15 18 36](https://user-images.githubusercontent.com/108270776/221897150-8ca10dad-5e79-4ace-96d7-6534b56872f5.png)
