### PR TITLE
Use backticks to fix unexpected token error

### DIFF
--- a/legacy/src/capi-single-paidfor/web/index.html
+++ b/legacy/src/capi-single-paidfor/web/index.html
@@ -53,8 +53,8 @@
   <div class="adverts__body"></div>
 </aside>
 <script>
-  var arrowRight = "{{#svg}}arrow-right{{/svg}}";
-  var audioIcon = "{{#svg}}audio{{/svg}}";
-  var imageIcon = "{{#svg}}image{{/svg}}";
-  var videoIcon = "{{#svg}}video{{/svg}}";
+  var arrowRight = `{{#svg}}arrow-right{{/svg}}`;
+  var audioIcon = `{{#svg}}audio{{/svg}}`;
+  var imageIcon = `{{#svg}}image{{/svg}}`;
+  var videoIcon = `{{#svg}}video{{/svg}}`;
 </script>


### PR DESCRIPTION
## What does this change?
The capi single paid-for template was broken when the first capi entry had a video associated with it. This is because the videoIcon was undefined, due to speech marks breaking up the variable assignment. Adding backticks to the var declaration ensures the video icon is correctly defined, and that the creative can be rendered.

VideoIcon was defined like this:
<img width="440" alt="Screenshot 2023-07-03 at 17 50 37" src="https://github.com/guardian/commercial-templates/assets/108270776/d674ed5b-56dd-41b0-ad06-345b2ebef9bd">
With this PR it becomes:
<img width="424" alt="Screenshot 2023-07-03 at 17 51 40" src="https://github.com/guardian/commercial-templates/assets/108270776/58e52c6c-77da-4ed2-ab9f-c96e6a1c65b0">

## Images
Creative doesn't load any content:
<img width="1505" alt="Screenshot 2023-07-03 at 17 50 22" src="https://github.com/guardian/commercial-templates/assets/108270776/ae2fdd31-720b-4cb0-a01c-5bf63d9a4f48">
Creative loads correctly:
<img width="772" alt="Screenshot 2023-07-03 at 17 48 35" src="https://github.com/guardian/commercial-templates/assets/108270776/a4f5eb22-09b5-48ea-897c-ba6d4dba5c00">
