### PR TITLE
JS tracking field - added at request from Programmatic ops

### DIFF
--- a/legacy/src/programmatic-dmpu/test.json
+++ b/legacy/src/programmatic-dmpu/test.json
@@ -4,5 +4,6 @@
   "TrackingPixel": "https://gu.com/tracking-pixel.gif",
   "ResearchPixel": "https://gu.com/research-pixel.gif",
   "ViewabilityTracker": "<img src='https://gu.com/viewability-tracker.gif'>",
-  "BackgroundImage":"https://adops-assets.s3.amazonaws.com/dap-fabrics/prog-dmpu-test-image/dmpu-test.jpg"
+  "BackgroundImage":"https://adops-assets.s3.amazonaws.com/dap-fabrics/prog-dmpu-test-image/dmpu-test.jpg",
+  "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>"
 }

--- a/legacy/src/programmatic-dmpu/web/index.html
+++ b/legacy/src/programmatic-dmpu/web/index.html
@@ -7,3 +7,4 @@
   <img src="[%ResearchPixel%]%%CACHEBUSTER%%" class="creative__pixel">
   <img src="[%ViewabilityTracker%]%%CACHEBUSTER%%" class="creative__pixel">
 <div>
+[%thirdPartyJSTracking%]

--- a/legacy/src/programmatic-mpu/test.json
+++ b/legacy/src/programmatic-mpu/test.json
@@ -4,5 +4,6 @@
   "TrackingPixel": "https://gu.com/tracking-pixel.gif",
   "ResearchPixel": "https://gu.com/research-pixel.gif",
   "ViewabilityTracker": "<img src='https://gu.com/viewability-tracker.gif'>",
-  "BackgroundImage":"https://adops-assets.s3.amazonaws.com/SkySports_Aug18_Background.jpg"
+  "BackgroundImage":"https://adops-assets.s3.amazonaws.com/SkySports_Aug18_Background.jpg",
+  "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>"
 }

--- a/legacy/src/programmatic-mpu/web/index.html
+++ b/legacy/src/programmatic-mpu/web/index.html
@@ -7,3 +7,4 @@
   <img src="[%ResearchPixel%]%%CACHEBUSTER%%" class="creative__pixel">
   <img src="[%ViewabilityTracker%]%%CACHEBUSTER%%" class="creative__pixel">
 <div>
+[%thirdPartyJSTracking%]


### PR DESCRIPTION
## What does this change?

Adops often have to added JS tracking tags to creatives. Currently Fabrics have this field, but the two templates programmatic ops use( programmatic-mpu and  programmatic-dmpu) do not. This changes brings those templates inline with the Fabrics.


## How to test

NPM run preview 

check the programmatic-mpu  and programmatic-dmpu preview in dev tools. Should be able to the test JS tag.

<img width="798" alt="Picture 29" src="https://github.com/guardian/commercial-templates/assets/371350/68cb320a-35cd-46b9-a35f-5e920998edb7">



