### PR TITLE
Add video source parameter to interscroller

### DIFF
--- a/src/lib/messenger.ts
+++ b/src/lib/messenger.ts
@@ -22,7 +22,7 @@ type BackgroundMessage = StandardMessage<
 	'background',
 	{
 		scrollType: string;
-		backgroundImage?: string;
+		backgroundImage: string;
 		backgroundRepeat: string;
 		backgroundPosition: string;
 		backgroundSize: string;

--- a/src/lib/messenger.ts
+++ b/src/lib/messenger.ts
@@ -22,11 +22,12 @@ type BackgroundMessage = StandardMessage<
 	'background',
 	{
 		scrollType: string;
-		backgroundImage: string;
+		backgroundImage?: string;
 		backgroundRepeat: string;
 		backgroundPosition: string;
 		backgroundSize: string;
 		ctaUrl: string;
+		videoSource: string;
 	}
 >;
 

--- a/src/templates/ssr/interscroller/index.ts
+++ b/src/templates/ssr/interscroller/index.ts
@@ -15,6 +15,7 @@ post({
 		backgroundPosition: 'center center',
 		backgroundSize: 'cover',
 		ctaUrl: `%%CLICK_URL_UNESC%%%%DEST_URL%%`,
+		videoSource: `[%VideoSource%]`,
 	},
 });
 


### PR DESCRIPTION
## What does this change?
Adds a parameter called videoSource to the interscroller template. This allows the a video to be added to the native interscroller template. If defined, the commercial code will create and add a video html tag to the interscroller ad.

For video interscrollers, the backgroundImage will display behind the video and will act as a fallback if the video fails to load, so it should still be defined for these ads.

Demo video:

https://github.com/guardian/commercial-templates/assets/108270776/c164922d-da41-40d3-9992-cbcb3a4e278b

