### PR TITLE
Sw fabric standard svelte - WIP

### DIFF
--- a/src/templates/components/AdvertismentLabel.svelte
+++ b/src/templates/components/AdvertismentLabel.svelte
@@ -1,0 +1,50 @@
+<script></script>
+
+<div class="gs-container creative__label creative__label">
+    <div class="creative__label-text">
+        Advertisement
+    </div>
+</div>
+
+<style lang="scss">
+
+    .gs-container {
+        position: relative;
+
+        @media (min-width: 46.25em) {
+            padding: 0 calc(50% - 370px);
+        }
+
+        @media (min-width: 61.25em) {
+            padding: 0 calc(50% - 490px);
+        }
+
+        @media (min-width: 71.25em) {
+            padding: 0 calc(50% - 570px);
+        }
+
+        @media (min-width: 81.25em) {
+            padding: 0 calc(50% - 650px);
+        }
+    }
+
+    .creative__label {
+        background-color: #f6f6f6;
+        border-top: 1px solid #dfdfdf;
+        color: #6e6e6e;
+        font: .75rem/1.9 "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+        height: 2em;
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box
+    }
+
+    .creative__label-text {
+        padding: 0 10px
+    }
+
+    @media (min-width:46.25em) {
+    .creative__label-text {
+        padding: 0 20px
+    }
+}
+</style>

--- a/src/templates/components/Pixel.svelte
+++ b/src/templates/components/Pixel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import type { GAMVariable } from '../../lib/gam';
+	export let src: GAMVariable;
+</script>
+
+<img src="{src}" alt="" />
+
+<style lang="scss">
+    img {
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		width: 1px;
+		height: 1px;
+		opacity: 0;
+	}
+</style>

--- a/src/templates/components/ThirdPartyTracking.svelte
+++ b/src/templates/components/ThirdPartyTracking.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import type { GAMVariable } from '../../lib/gam';
+
+    export let TrackingScript: GAMVariable;
+</script>
+
+<slot>
+    {TrackingScript}
+</slot>
+
+
+<style lang="scss"></style>

--- a/src/templates/ssr/fabric/index.svelte
+++ b/src/templates/ssr/fabric/index.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+    import type { GAMVariable } from "../../../lib/gam";
+    import AdvertismentLabel from "$templates/components/AdvertismentLabel.svelte";
+    import ThirdPartyTracking from "$templates/components/ThirdPartyTracking.svelte";
+    import Pixel from "$templates/components/Pixel.svelte";
+
+    export let Layer1BackgroundImage: GAMVariable;
+    export let Layer2BackgroundImage: GAMVariable;
+    export let Layer3BackgroundImage: GAMVariable;
+
+    export let MobileLayer1BackgroundImage: GAMVariable;
+    export let MobileLayer2BackgroundImage: GAMVariable;
+    export let MobileLayer3BackgroundImage: GAMVariable;
+
+    export let Layer1BackgroundPosition: GAMVariable;
+    export let Layer2BackgroundPosition: GAMVariable;
+    export let Layer3BackgroundPosition: GAMVariable;
+
+    export let MobileLayer1BackgroundPosition: GAMVariable;
+    export let MobileLayer2BackgroundPosition: GAMVariable;
+    export let MobileLayer3BackgroundPosition: GAMVariable;
+
+    export let Trackingpixel: GAMVariable;
+    export let Researchpixel: GAMVariable;
+    export let Viewabilitypixel: GAMVariable;
+
+    export let thirdPartyJSTracking: GAMVariable;
+
+</script>
+
+<AdvertismentLabel />
+<div class="creative creative--fabric">
+    <!--desktop-->
+    <a id="linkDesktop" class="blink gs-container creative__link until-tablet"
+        href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+        <div class="u-root">
+            <div class="creative__alt creative__alt--tablet">
+                <div class="creative__layer creative__layer1" style={`background-image: url(${Layer1BackgroundImage}); background-position: ${Layer1BackgroundPosition};`}></div>
+                <div id="layer2" class="creative__layer creative__layer2" 
+                style={`background-image: url(${Layer2BackgroundImage}); background-position: ${Layer2BackgroundPosition};`} >
+                    </div>
+                <div class="creative__layer creative__layer3"
+                style={`background-image: url(${Layer3BackgroundImage}); background-position: ${Layer3BackgroundPosition};`}
+                    ></div>
+            </div>
+        </div>
+    </a>
+
+    <!--mobile-->
+    <a id="linkMobile" class="blink gs-container creative__link mobile-only"
+    href="%%CLICK_URL_UNESC%%%%DEST_URL%%">
+        <div class="u-root">
+            <div class="creative__alt creative__alt--mobile">
+                <div class="creative__layer creative__layer1"
+            style={`background-image: url(${MobileLayer1BackgroundImage}); background-position: ${MobileLayer1BackgroundPosition};`}
+                ></div>
+            <div class="creative__layer creative__layer2"
+                style={`background-image: url(${MobileLayer2BackgroundImage}); background-position: ${MobileLayer2BackgroundPosition};`}
+                ></div>
+            <div class="creative__layer creative__layer3"
+            style={`background-image: url(${MobileLayer3BackgroundImage}); background-position: ${MobileLayer3BackgroundPosition};`}
+            ></div>
+        </div>
+    </div>
+    </a>
+    <Pixel src={Trackingpixel} />
+    <Pixel src={Researchpixel} />
+    <Pixel src={Viewabilitypixel} />
+</div>
+<ThirdPartyTracking
+TrackingScript={thirdPartyJSTracking}
+/>
+
+
+
+<style lang="scss">
+
+.u-root {
+    position: relative;
+}
+
+.gs-container {
+    position: relative;
+
+    @media (min-width: 46.25em) {
+        padding: 0 calc(50% - 370px);
+    }
+
+    @media (min-width: 61.25em) {
+        padding: 0 calc(50% - 490px);
+    }
+
+    @media (min-width: 71.25em) {
+        padding: 0 calc(50% - 570px);
+    }
+
+
+    @media (min-width: 81.25em) {
+        padding: 0 calc(50% - 650px);
+    }
+}
+
+.creative.creative--fabric {
+    display: block;
+    position: relative
+}
+
+.creative--fabric {
+    &, .creative__link {
+        height: 250px;
+        overflow: hidden;
+    }
+}
+
+.creative__layer1 { z-index: 1; }
+.creative__layer2 { z-index: 2; }
+.creative__layer3 { z-index: 3; }
+
+.creative__alt, .creative__layer {
+        width: 100%;
+        height: 250px;
+        position: absolute;
+        inset: 0;
+        background-repeat: no-repeat;
+        background-size: cover;
+}
+
+.blink {
+    display: block;
+    text-decoration: none;
+}
+
+.mobile-only {
+    display: none;
+}
+
+@media (max-width: 740px) {
+    .until-tablet {
+        display: none;
+    }
+
+    .mobile-only {
+        display: block;
+    }
+}
+
+</style>

--- a/src/templates/ssr/fabric/test.json
+++ b/src/templates/ssr/fabric/test.json
@@ -1,0 +1,20 @@
+{
+    "ClickthroughUrl": "http://www.chloe.com/en/content/faye",
+    "Trackingpixel": "",
+    "Researchpixel": "",
+    "Viewabilitypixel": "",
+    "thirdPartyJSTracking": "<SCRIPT TYPE='application/javascript' SRC='https://pixel.adsafeprotected.com/rjss/st/726370/54949606/skeleton.js'></SCRIPT> <NOSCRIPT><IMG SRC='https://pixel.adsafeprotected.com/rfw/st/726370/54949605/skeleton.gif?gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_278}&gdpr_pd=${GDPR_PD}' BORDER=0 WIDTH=1 HEIGHT=1 ALT=''></NOSCRIPT>",
+    "Layer1BackgroundImage": "https://tpc.googlesyndication.com/simgad/1295361312767537196?",
+    "Layer1BackgroundPosition": "center center",
+    "Layer2BackgroundImage": "https://tpc.googlesyndication.com/simgad/15563857437127191912?",
+    "Layer2BackgroundPosition": "right top",
+    "Layer3BackgroundImage": "https://tpc.googlesyndication.com/simgad/5288096334821896354?",
+    "Layer3BackgroundPosition": "left top",
+    "MobileLayer1BackgroundImage": "https://tpc.googlesyndication.com/simgad/2533948028937912963?",
+    "MobileLayer1BackgroundPosition": "center center",
+    "MobileLayer2BackgroundImage": "https://tpc.googlesyndication.com/simgad/17563917737287954751?",
+    "MobileLayer2BackgroundPosition": "left top",
+    "MobileLayer3BackgroundImage": "https://tpc.googlesyndication.com/simgad/8934307222711165803?",
+    "MobileLayer3BackgroundPosition": "right top"
+  }
+  


### PR DESCRIPTION
Standard Svelte update of the fabric standard template with no JS. The current template has an animation and parallax option, but is very rarely used. 





## What does this change?
Replaces the existing standard fabric template.

## How to test
Native template 
https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=279700&tab=ad_settings


Line item example
https://admanager.google.com/59666047#creatives/creative/detail/line_item_id=6407188528&creative_id=138452188059

Ad test 
https://www.theguardian.com/uk/culture?adtest=svelte_fabric




## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->




