### PR TITLE
Migrate CAPI Multiple Hosted template to Svelte

### DIFF
--- a/legacy/src/_shared/js/dom.js
+++ b/legacy/src/_shared/js/dom.js
@@ -23,7 +23,6 @@ let img = createElement('img');
 let div = createElement('div');
 
 export {
-    closest,
     write,
     read,
     img,

--- a/src/lib/Previews.svelte
+++ b/src/lib/Previews.svelte
@@ -8,7 +8,6 @@
 <script lang="ts">
 	import { replaceGAMVariables } from '$lib/gam';
 	import { onMount } from 'svelte';
-	import type { Message } from './messenger';
 	import { tones } from './types/tones';
 
 	export let template: string;

--- a/src/lib/capiMultiple.ts
+++ b/src/lib/capiMultiple.ts
@@ -32,14 +32,19 @@ function addCapiHostedCardOverrides(
 	return {
 		logo: (overrideLogo || cardData[0]?.branding.logo.src) ?? null,
 		cards: cardData
-			.map((capiCard, i) => ({
-				...capiCard,
-				headline: overrideCards[i]?.headline ?? capiCard.articleHeadline,
-				image: overrideCards[i]?.image
-					? { sources: [], backupSrc: overrideCards[i]?.image ?? '' }
-					: cardData[i]?.articleImage,
-				url: capiCard.articleUrl,
-			}))
+			.map((capiCard, i) => {
+				const headlineOverride = overrideCards[i]?.headline ?? '';
+				const imageOverride = overrideCards[i]?.image ?? '';
+
+				return {
+					...capiCard,
+					headline: headlineOverride || capiCard.articleHeadline,
+					image: imageOverride
+						? { sources: [], backupSrc: overrideCards[i]?.image ?? '' }
+						: cardData[i]?.articleImage,
+					url: capiCard.articleUrl,
+				};
+			})
 			// A card should only be displayed if and only if a headline is available
 			.filter((card) => card.headline !== ''),
 	};

--- a/src/lib/capiMultiple.ts
+++ b/src/lib/capiMultiple.ts
@@ -1,45 +1,46 @@
 import type { GAMVariable } from './gam';
-import type { CapiCard, CapiCardOverride, Single } from './types/capi';
+import type { CapiCardOverride, CapiHostedCard, Single } from './types/capi';
 
 const apiEndpoint =
 	'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-multiple.json';
 
-function addHeadlineKicker(
-	overrideCards: CapiCardOverride[],
+function addCapiCardOverrides(
 	cardData: Single[],
-) {
-	for (let i = 0; i < overrideCards.length; i++) {
-		if (overrideCards[i]?.kicker && overrideCards[i]?.headline) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- headline should always be defined
-			cardData[i]!.articleHeadline = overrideCards[i]?.headline as string;
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we define the kicker here - it's an optional parameter
-			cardData[i]!.articleKicker = overrideCards[i]?.kicker as string;
-		}
-	}
+	overrideCards: CapiCardOverride[],
+): Single[] {
+	return cardData.map((capiCard, i) => {
+		const headlineOverride = overrideCards[i]?.headline;
+		const kickerOverride = overrideCards[i]?.kicker;
 
-	return cardData;
+		if (headlineOverride && kickerOverride) {
+			return {
+				...capiCard,
+				articleHeadline: headlineOverride,
+				articleKicker: kickerOverride,
+			};
+		}
+
+		return capiCard;
+	});
 }
 
-function addOverridesToCardData(
+function addCapiHostedCardOverrides(
 	cardData: Single[],
 	overrideCards: CapiCardOverride[],
 	overrideLogo: string,
-): { logo: string | null; cards: CapiCard[] } {
+): { logo: string | null; cards: CapiHostedCard[] } {
 	return {
 		logo: (overrideLogo || cardData[0]?.branding.logo.src) ?? null,
 		cards: cardData
 			.map((capiCard, i) => ({
-				...cardData,
+				...capiCard,
 				headline: overrideCards[i]?.headline ?? capiCard.articleHeadline,
-				url: overrideCards[i]?.url ?? capiCard.articleUrl,
 				image: overrideCards[i]?.image
 					? { sources: [], backupSrc: overrideCards[i]?.image ?? '' }
 					: cardData[i]?.articleImage,
-				audioTag: capiCard.audioTag,
-				galleryTag: capiCard.galleryTag,
-				videoTag: capiCard.videoTag,
+				url: capiCard.articleUrl,
 			}))
-			// A card will be displayed if and only if a headline is available
+			// A card should only be displayed if and only if a headline is available
 			.filter((card) => card.headline !== ''),
 	};
 }
@@ -59,4 +60,4 @@ async function retrieveCapiData(
 	return fetch(request).then((response) => response.json());
 }
 
-export { retrieveCapiData, addOverridesToCardData, addHeadlineKicker };
+export { retrieveCapiData, addCapiHostedCardOverrides, addCapiCardOverrides };

--- a/src/lib/capiMultiple.ts
+++ b/src/lib/capiMultiple.ts
@@ -1,5 +1,5 @@
 import type { GAMVariable } from './gam';
-import type { CapiCardOverride, Single } from './types/capi';
+import type { CapiCard, CapiCardOverride, Single } from './types/capi';
 
 const apiEndpoint =
 	'https://api.nextgen.guardianapps.co.uk/commercial/api/capi-multiple.json';
@@ -13,21 +13,50 @@ function addHeadlineKicker(
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- headline should always be defined
 			cardData[i]!.articleHeadline = overrideCards[i]?.headline as string;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we define the kicker here - it's an optional parameter
-			cardData[i]!.kicker = overrideCards[i]?.kicker as string;
+			cardData[i]!.articleKicker = overrideCards[i]?.kicker as string;
 		}
 	}
 
 	return cardData;
 }
 
-function retrieveCapiData(cards: CapiCardOverride[], seriesUrl: GAMVariable) {
-	let request = `${apiEndpoint}?k=${encodeURI(seriesUrl)}`;
-	cards.forEach((card) => {
-		if (card.url) {
-			request += `&t=${encodeURI(card.url)}`;
+function addOverridesToCardData(
+	cardData: Single[],
+	overrideCards: CapiCardOverride[],
+	overrideLogo: string,
+): { logo: string | null; cards: CapiCard[] } {
+	return {
+		logo: (overrideLogo || cardData[0]?.branding.logo.src) ?? null,
+		cards: cardData
+			.map((capiCard, i) => ({
+				...cardData,
+				headline: overrideCards[i]?.headline ?? capiCard.articleHeadline,
+				url: overrideCards[i]?.url ?? capiCard.articleUrl,
+				image: overrideCards[i]?.image
+					? { sources: [], backupSrc: overrideCards[i]?.image ?? '' }
+					: cardData[i]?.articleImage,
+				audioTag: capiCard.audioTag,
+				galleryTag: capiCard.galleryTag,
+				videoTag: capiCard.videoTag,
+			}))
+			// A card will be displayed if and only if a headline is available
+			.filter((card) => card.headline !== ''),
+	};
+}
+
+async function retrieveCapiData(
+	seriesUrl: GAMVariable,
+	cardOverrides: CapiCardOverride[],
+) {
+	const request = new URL(apiEndpoint);
+	request.searchParams.append('k', encodeURI(seriesUrl));
+	cardOverrides.forEach(({ url }) => {
+		if (url) {
+			request.searchParams.append('t', url);
 		}
 	});
+
 	return fetch(request).then((response) => response.json());
 }
 
-export { retrieveCapiData, addHeadlineKicker };
+export { retrieveCapiData, addOverridesToCardData, addHeadlineKicker };

--- a/src/lib/types/capi.ts
+++ b/src/lib/types/capi.ts
@@ -49,17 +49,16 @@ export type Single = {
 	branding: Branding;
 };
 
-export type CapiCard = {
+export type CapiHostedCard = {
 	headline: string;
 	url: string;
-	audioTag?: boolean;
-	galleryTag?: boolean;
-	videoTag?: boolean;
 	image?: {
 		sources: Source[];
 		backupSrc: string;
 	};
-	kicker?: string;
+	audioTag?: boolean;
+	galleryTag?: boolean;
+	videoTag?: boolean;
 };
 
 export type CapiCardOverride = {

--- a/src/lib/types/capi.ts
+++ b/src/lib/types/capi.ts
@@ -37,8 +37,9 @@ export type Branding = {
 export type Single = {
 	articleHeadline: string;
 	articleText: string;
+	articleKicker: string;
 	articleUrl: string;
-	articleImage: {
+	articleImage?: {
 		sources: Source[];
 		backupSrc: string;
 	};
@@ -46,12 +47,24 @@ export type Single = {
 	galleryTag: boolean;
 	videoTag: boolean;
 	branding: Branding;
+};
+
+export type CapiCard = {
+	headline: string;
+	url: string;
+	audioTag?: boolean;
+	galleryTag?: boolean;
+	videoTag?: boolean;
+	image?: {
+		sources: Source[];
+		backupSrc: string;
+	};
 	kicker?: string;
 };
 
 export type CapiCardOverride = {
 	headline: GAMVariable;
-	image: GAMVariable;
 	url: GAMVariable;
-	kicker: GAMVariable;
+	image: GAMVariable;
+	kicker?: GAMVariable;
 };

--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -11,7 +11,6 @@
 
 	export let templateType: 'single' | 'multiple';
 	export let single: Single;
-	export let direction = 'row';
 
 	const {
 		articleHeadline,
@@ -28,12 +27,7 @@
 		articleImage && articleImage.sources.length > 0 && 'srcset' in new Image();
 </script>
 
-<a
-	class="{templateType}-card"
-	href={clickMacro(articleUrl)}
-	target="_top"
-	style={`--direction: ${direction}`}
->
+<a class="{templateType}-card" href={clickMacro(articleUrl)} target="_top">
 	<div class="media">
 		{#if pictureSupported}
 			<picture>

--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -17,14 +17,15 @@
 		articleHeadline,
 		articleUrl,
 		articleText,
+		articleKicker,
 		articleImage,
 		audioTag,
 		galleryTag,
 		videoTag,
-		kicker,
 	} = single;
+
 	const pictureSupported =
-		articleImage.sources.length > 0 && 'srcset' in new Image();
+		articleImage && articleImage.sources.length > 0 && 'srcset' in new Image();
 </script>
 
 <a
@@ -51,14 +52,14 @@
 				{/each}
 				<img src={articleImage.backupSrc} alt="" />
 			</picture>
-		{:else}
+		{:else if articleImage?.backupSrc}
 			<img src={articleImage.backupSrc} alt="" />
 		{/if}
 	</div>
 	<div class="text">
 		<h2>
-			{#if kicker}
-				<span class="kicker">{kicker && kicker}</span><br />
+			{#if articleKicker}
+				<span class="kicker">{articleKicker && articleKicker}</span><br />
 			{/if}
 			{#if audioTag}
 				<AudioIcon />

--- a/src/templates/components/CapiHostedCard.svelte
+++ b/src/templates/components/CapiHostedCard.svelte
@@ -3,19 +3,19 @@
 </script>
 
 <script lang="ts">
+	import type { CapiHostedCard } from '$lib/types/capi';
 	import AudioIcon from './icons/AudioIcon.svelte';
 	import CameraIcon from './icons/CameraIcon.svelte';
 	import VideoIcon from './icons/VideoIcon.svelte';
 
-	export let card;
+	export let card: CapiHostedCard;
 
 	const { headline, image, url, audioTag, galleryTag, videoTag } = card;
 
-	const pictureSupported =
-		image?.sources?.length > 0 && 'srcset' in new Image();
+	const pictureSupported = image?.sources?.length && 'srcset' in new Image();
 </script>
 
-<a href={clickMacro(url)}>
+<a href={clickMacro(url)} target="_top">
 	<div class="media">
 		{#if pictureSupported}
 			<picture>
@@ -34,7 +34,7 @@
 				{/each}
 				<img src={image.backupSrc} alt="" />
 			</picture>
-		{:else if image.backupSrc}
+		{:else if image?.backupSrc}
 			<img src={image.backupSrc} alt="" />
 		{/if}
 	</div>

--- a/src/templates/components/CapiHostedCard.svelte
+++ b/src/templates/components/CapiHostedCard.svelte
@@ -1,3 +1,7 @@
+<script context="module" lang="ts">
+	import { clickMacro } from '$lib/gam';
+</script>
+
 <script lang="ts">
 	import AudioIcon from './icons/AudioIcon.svelte';
 	import CameraIcon from './icons/CameraIcon.svelte';
@@ -11,7 +15,7 @@
 		image?.sources?.length > 0 && 'srcset' in new Image();
 </script>
 
-<a href={url}>
+<a href={clickMacro(url)}>
 	<div class="media">
 		{#if pictureSupported}
 			<picture>

--- a/src/templates/components/CapiHostedCard.svelte
+++ b/src/templates/components/CapiHostedCard.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import AudioIcon from './icons/AudioIcon.svelte';
+	import CameraIcon from './icons/CameraIcon.svelte';
+	import VideoIcon from './icons/VideoIcon.svelte';
+
+	export let card;
+
+	const { headline, image, url, audioTag, galleryTag, videoTag } = card;
+
+	const pictureSupported =
+		image?.sources?.length > 0 && 'srcset' in new Image();
+</script>
+
+<a href={url}>
+	<div class="media">
+		{#if pictureSupported}
+			<picture>
+				{#each image.sources.filter((source) => source.minWidth === '0') as source}
+					<source
+						media={`(min-width: ${source.minWidth}px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: ${source.minWidth}px) and (min-resolution: 120dpi)`}
+						srcset={source.hidpiSrcset}
+						sizes={source.sizes}
+					/>
+
+					<source
+						media={`(min-width: ${source.minWidth}px)`}
+						srcset={source.lodpiSrcset}
+						sizes={source.sizes}
+					/>
+				{/each}
+				<img src={image.backupSrc} alt="" />
+			</picture>
+		{:else if image.backupSrc}
+			<img src={image.backupSrc} alt="" />
+		{/if}
+	</div>
+	<h2>
+		{#if audioTag}
+			<AudioIcon />
+		{:else if galleryTag}
+			<CameraIcon />
+		{:else if videoTag}
+			<VideoIcon />
+		{/if}
+		{headline}
+	</h2>
+</a>
+
+<style lang="scss">
+	a {
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 auto;
+		max-height: 400px;
+		max-width: 700px;
+		text-decoration: none;
+		background-color: var(--brand-colour);
+	}
+
+	a:hover,
+	a:focus {
+		opacity: 0.9;
+	}
+
+	a:nth-child(n + 2) {
+		img {
+			display: none;
+		}
+	}
+
+	picture,
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	h2 {
+		margin: 0;
+		padding: 0.3em 0.3em 0.9em;
+		color: #fff;
+		font-size: 1.15rem;
+		line-height: 1.5rem;
+		font-weight: 400;
+		overflow: hidden;
+	}
+
+	:global(svg.icon) {
+		fill: #fff;
+		opacity: 0.5;
+		height: 0.7em;
+		width: 1.2em;
+		line-height: inherit;
+		margin-right: 0.1em;
+	}
+
+	@media (min-width: 425px) {
+		a:nth-child(2) {
+			img {
+				display: inline;
+			}
+		}
+
+		a:nth-child(n + 3) {
+			grid-column-start: span 2;
+			img {
+				display: none;
+			}
+		}
+	}
+
+	@media (min-width: 740px) {
+		.media {
+			max-height: 60%;
+		}
+
+		a:nth-child(n + 2) {
+			grid-column-start: span 1;
+		}
+
+		a:nth-child(n + 3) {
+			img {
+				display: inline;
+			}
+		}
+	}
+</style>

--- a/src/templates/components/HostedHeader.svelte
+++ b/src/templates/components/HostedHeader.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import '$templates/components/fonts/SansBold.css';
+
+	export let logo: string | null;
+</script>
+
+<header>
+	<h1>From our advertisers</h1>
+	{#if logo}
+		<div class="logo">
+			<div>Advertiser content</div>
+			<img src={logo} alt="advertiser logo" />
+		</div>
+	{/if}
+</header>
+
+<style lang="scss">
+	header {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	h1 {
+		font-size: 1.25rem;
+		font-weight: 700;
+		line-height: 1;
+		margin: 0;
+	}
+
+	.logo {
+		display: flex;
+		flex-direction: column;
+		background-color: #fff;
+		width: 5em;
+
+		div {
+			padding: 0.5em;
+			font-size: 0.75rem;
+			line-height: 1.1;
+			background-color: var(--brand-colour);
+			color: #fff;
+			text-align: start;
+		}
+
+		img {
+			width: 100%;
+		}
+	}
+
+	@media (min-width: 1140px) {
+		header {
+			flex-direction: column;
+		}
+
+		.logo {
+			width: 7em;
+
+			div {
+				padding: 6px 0 8px;
+				text-align: center;
+			}
+		}
+	}
+</style>

--- a/src/templates/components/HostedHeader.svelte
+++ b/src/templates/components/HostedHeader.svelte
@@ -25,7 +25,7 @@
 		font-size: 1.25rem;
 		font-weight: 700;
 		line-height: 1;
-		margin: 0;
+		margin: 6px 0 0;
 	}
 
 	.logo {

--- a/src/templates/csr/capi-multiple-hosted/ad.json
+++ b/src/templates/csr/capi-multiple-hosted/ad.json
@@ -1,0 +1,3 @@
+{
+	"nativeStyleId": "84508"
+}

--- a/src/templates/csr/capi-multiple-hosted/index.svelte
+++ b/src/templates/csr/capi-multiple-hosted/index.svelte
@@ -34,6 +34,7 @@
 	export let Article4Headline: GAMVariable;
 	export let Article4Image: GAMVariable;
 	export let Article4URL: GAMVariable;
+	export let numberOfElements: GAMVariable;
 
 	let cardOverrides: CapiCardOverride[] = [
 		{
@@ -59,7 +60,11 @@
 	];
 
 	const getCards = retrieveCapiData(SeriesURL, cardOverrides).then((response) =>
-		addCapiHostedCardOverrides(response.articles, cardOverrides, BrandLogo),
+		addCapiHostedCardOverrides(
+			response.articles.slice(0, numberOfElements),
+			cardOverrides,
+			BrandLogo,
+		),
 	);
 
 	if (isValidReplacedVariable(TrackingId)) addTrackingPixel(TrackingId);

--- a/src/templates/csr/capi-multiple-hosted/index.svelte
+++ b/src/templates/csr/capi-multiple-hosted/index.svelte
@@ -82,7 +82,7 @@
 			{/each}
 		</div>
 	{:catch}
-		<h3>An error has occurred whilst loading content</h3>
+		<h3>An error occurred whilst loading content</h3>
 	{/await}
 </aside>
 <Resizer {height} />

--- a/src/templates/csr/capi-multiple-hosted/index.svelte
+++ b/src/templates/csr/capi-multiple-hosted/index.svelte
@@ -1,0 +1,183 @@
+<script context="module" lang="ts">
+	import '$templates/components/fonts/Sans.css';
+	import '$templates/components/fonts/SansBold.css';
+</script>
+
+<script lang="ts">
+	import {
+		isValidReplacedVariable,
+		type GAMVariable,
+		addTrackingPixel,
+	} from '$lib/gam.js';
+	import CapiHostedCard from '$templates/components/CapiHostedCard.svelte';
+	import Resizer from '$templates/components/Resizer.svelte';
+	import { addOverridesToCardData, retrieveCapiData } from '$lib/capiMultiple';
+	import type { CapiCardOverride } from '$lib/types/capi';
+
+	export let SeriesURL: GAMVariable;
+	export let BrandLogo: GAMVariable;
+	export let BrandColour: GAMVariable;
+	export let TrackingId: GAMVariable;
+	export let Article1Headline: GAMVariable;
+	export let Article1Image: GAMVariable;
+	export let Article1URL: GAMVariable;
+	export let Article2Headline: GAMVariable;
+	export let Article2Image: GAMVariable;
+	export let Article2URL: GAMVariable;
+	export let Article3Headline: GAMVariable;
+	export let Article3Image: GAMVariable;
+	export let Article3URL: GAMVariable;
+	export let Article4Headline: GAMVariable;
+	export let Article4Image: GAMVariable;
+	export let Article4URL: GAMVariable;
+
+	let cardOverrides: CapiCardOverride[] = [
+		{
+			headline: Article1Headline,
+			image: Article1Image,
+			url: Article1URL,
+		},
+		{
+			headline: Article2Headline,
+			image: Article2Image,
+			url: Article2URL,
+		},
+		{
+			headline: Article3Headline,
+			image: Article3Image,
+			url: Article3URL,
+		},
+		{
+			headline: Article4Headline,
+			image: Article4Image,
+			url: Article4URL,
+		},
+	];
+
+	const getCards = retrieveCapiData(SeriesURL, cardOverrides).then((response) =>
+		addOverridesToCardData(response.articles, cardOverrides, BrandLogo),
+	);
+
+	if (isValidReplacedVariable(TrackingId)) addTrackingPixel(TrackingId);
+
+	let height: number = -1;
+</script>
+
+<aside bind:clientHeight={height} style="--brand-colour: {BrandColour}">
+	{#await getCards}
+		<h3>Loading Content...</h3>
+	{:then multiple}
+		<div class="header">
+			<h1>From our advertisers</h1>
+			{#if multiple.logo}
+				<div class="logo">
+					<div>Advertiser content</div>
+					<img src={multiple.logo} alt="advertiser logo" />
+				</div>
+			{/if}
+		</div>
+		<div class="cards-container">
+			{#each multiple.cards as card}
+				<CapiHostedCard {card} />
+			{/each}
+		</div>
+	{:catch}
+		<h3>An error has occurred whilst loading content</h3>
+	{/await}
+</aside>
+<Resizer {height} />
+
+<style lang="scss">
+	aside {
+		max-width: 1300px;
+		position: relative;
+		display: grid;
+		gap: 1em;
+		padding: 6px 10px 10px;
+		background: #f6f6f6;
+		font-family: 'GuardianTextSans', 'Helvetica Neue', Helvetica, Arial,
+			'Lucida Grande', sans-serif;
+		font-kerning: normal;
+		text-rendering: optimizelegibility;
+		font-variant-ligatures: common-ligatures;
+	}
+
+	.header {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	h1 {
+		font-size: 1.25rem;
+		font-weight: 700;
+		line-height: 1;
+		margin: 0;
+	}
+
+	.logo {
+		display: flex;
+		flex-direction: column;
+		background-color: #fff;
+		width: 5em;
+
+		div {
+			padding: 0.5em;
+			font-size: 0.75rem;
+			line-height: 1.1;
+			background-color: var(--brand-colour);
+			color: #fff;
+			text-align: start;
+		}
+
+		img {
+			width: 100%;
+		}
+	}
+
+	.cards-container {
+		display: grid;
+		grid-template-columns: 1fr;
+		row-gap: 0.5em;
+		background: #f6f6f6;
+		position: relative;
+	}
+
+	@media (min-width: 425px) {
+		aside {
+			padding: 6px 20px 20px;
+		}
+		.cards-container {
+			grid-template-columns: 1fr 1fr;
+			column-gap: 0.5em;
+		}
+	}
+
+	@media (min-width: 740px) {
+		.cards-container {
+			grid-template-columns: unset;
+			grid-auto-flow: column;
+			grid-auto-columns: minmax(0, 1fr);
+			gap: 1em;
+		}
+	}
+
+	@media (min-width: 1140px) {
+		aside {
+			grid-template-columns: 240px 1fr;
+		}
+
+		.header {
+			flex-direction: column;
+		}
+
+		.logo {
+			width: 7em;
+
+			div {
+				padding: 6px 0 8px;
+				text-align: center;
+			}
+		}
+	}
+</style>

--- a/src/templates/csr/capi-multiple-hosted/index.svelte
+++ b/src/templates/csr/capi-multiple-hosted/index.svelte
@@ -12,7 +12,10 @@
 	import CapiHostedCard from '$templates/components/CapiHostedCard.svelte';
 	import HostedHeader from '$templates/components/HostedHeader.svelte';
 	import Resizer from '$templates/components/Resizer.svelte';
-	import { addOverridesToCardData, retrieveCapiData } from '$lib/capiMultiple';
+	import {
+		addCapiHostedCardOverrides,
+		retrieveCapiData,
+	} from '$lib/capiMultiple';
 	import type { CapiCardOverride } from '$lib/types/capi';
 
 	export let SeriesURL: GAMVariable;
@@ -56,7 +59,7 @@
 	];
 
 	const getCards = retrieveCapiData(SeriesURL, cardOverrides).then((response) =>
-		addOverridesToCardData(response.articles, cardOverrides, BrandLogo),
+		addCapiHostedCardOverrides(response.articles, cardOverrides, BrandLogo),
 	);
 
 	if (isValidReplacedVariable(TrackingId)) addTrackingPixel(TrackingId);
@@ -86,8 +89,9 @@
 		position: relative;
 		display: grid;
 		gap: 1em;
-		padding: 6px 10px 10px;
-		background: #f6f6f6;
+		padding: 0 10px 10px;
+		background: #ededed;
+		border-top: 1px solid var(--brand-colour);
 		font-family: 'GuardianTextSans', 'Helvetica Neue', Helvetica, Arial,
 			'Lucida Grande', sans-serif;
 		font-kerning: normal;
@@ -101,11 +105,12 @@
 		row-gap: 0.5em;
 		background: #f6f6f6;
 		position: relative;
+		margin-top: 6px;
 	}
 
 	@media (min-width: 425px) {
 		aside {
-			padding: 6px 20px 20px;
+			padding: 0 20px 20px;
 		}
 		.cards-container {
 			grid-template-columns: 1fr 1fr;

--- a/src/templates/csr/capi-multiple-hosted/index.svelte
+++ b/src/templates/csr/capi-multiple-hosted/index.svelte
@@ -10,6 +10,7 @@
 		addTrackingPixel,
 	} from '$lib/gam.js';
 	import CapiHostedCard from '$templates/components/CapiHostedCard.svelte';
+	import HostedHeader from '$templates/components/HostedHeader.svelte';
 	import Resizer from '$templates/components/Resizer.svelte';
 	import { addOverridesToCardData, retrieveCapiData } from '$lib/capiMultiple';
 	import type { CapiCardOverride } from '$lib/types/capi';
@@ -67,15 +68,7 @@
 	{#await getCards}
 		<h3>Loading Content...</h3>
 	{:then multiple}
-		<div class="header">
-			<h1>From our advertisers</h1>
-			{#if multiple.logo}
-				<div class="logo">
-					<div>Advertiser content</div>
-					<img src={multiple.logo} alt="advertiser logo" />
-				</div>
-			{/if}
-		</div>
+		<HostedHeader logo={multiple.logo} />
 		<div class="cards-container">
 			{#each multiple.cards as card}
 				<CapiHostedCard {card} />
@@ -100,39 +93,6 @@
 		font-kerning: normal;
 		text-rendering: optimizelegibility;
 		font-variant-ligatures: common-ligatures;
-	}
-
-	.header {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-	}
-
-	h1 {
-		font-size: 1.25rem;
-		font-weight: 700;
-		line-height: 1;
-		margin: 0;
-	}
-
-	.logo {
-		display: flex;
-		flex-direction: column;
-		background-color: #fff;
-		width: 5em;
-
-		div {
-			padding: 0.5em;
-			font-size: 0.75rem;
-			line-height: 1.1;
-			background-color: var(--brand-colour);
-			color: #fff;
-			text-align: start;
-		}
-
-		img {
-			width: 100%;
-		}
 	}
 
 	.cards-container {
@@ -165,19 +125,6 @@
 	@media (min-width: 1140px) {
 		aside {
 			grid-template-columns: 240px 1fr;
-		}
-
-		.header {
-			flex-direction: column;
-		}
-
-		.logo {
-			width: 7em;
-
-			div {
-				padding: 6px 0 8px;
-				text-align: center;
-			}
 		}
 	}
 </style>

--- a/src/templates/csr/capi-multiple-hosted/test.json
+++ b/src/templates/csr/capi-multiple-hosted/test.json
@@ -1,0 +1,18 @@
+{
+	"SeriesURL": "advertiser-content/ipo-awareness",
+	"BrandLogo": "",
+	"BrandColour": "#5d7a25",
+	"TrackingID": "",
+	"Article1Headline": "The age of the password is ending – what comes next?",
+	"Article1Image": "",
+	"Article1URL": "p/pbzee",
+	"Article2Headline": "Does AI signal a new age of cyber threat?",
+	"Article2Image": "",
+	"Article2URL": "p/pbzff",
+	"Article3Headline": "How to shop online without falling for cyberscams",
+	"Article3Image": "",
+	"Article3URL": "p/pbzgd",
+	"Article4Headline": "Inside the mind of an ethical hacker",
+	"Article4Image": "",
+	"Article4URL": "p/pbzaf"
+}

--- a/src/templates/csr/capi-multiple-hosted/test.json
+++ b/src/templates/csr/capi-multiple-hosted/test.json
@@ -14,5 +14,6 @@
 	"Article3URL": "p/pbzgd",
 	"Article4Headline": "Inside the mind of an ethical hacker",
 	"Article4Image": "",
-	"Article4URL": "p/pbzaf"
+	"Article4URL": "p/pbzaf",
+	"numberOfElements": "4"
 }

--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -11,7 +11,7 @@
 	import PaidForHeader from '$templates/components/PaidForHeader.svelte';
 	import { addTrackingPixel, isValidReplacedVariable } from '$lib/gam';
 	import Resizer from '$templates/components/Resizer.svelte';
-	import { retrieveCapiData, addHeadlineKicker } from '$lib/capiMultiple';
+	import { retrieveCapiData, addCapiCardOverrides } from '$lib/capiMultiple';
 
 	export let SeriesURL: GAMVariable;
 	export let ComponentTitle: GAMVariable;
@@ -61,7 +61,7 @@
 	];
 
 	const getCards = retrieveCapiData(SeriesURL, cardOverrides).then((response) =>
-		addHeadlineKicker(cardOverrides, response.articles),
+		addCapiCardOverrides(response.articles, cardOverrides),
 	);
 
 	if (isValidReplacedVariable(Trackingpixel)) addTrackingPixel(Trackingpixel);

--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -60,7 +60,7 @@
 		},
 	];
 
-	const getCards = retrieveCapiData(cardOverrides, SeriesURL).then((response) =>
+	const getCards = retrieveCapiData(SeriesURL, cardOverrides).then((response) =>
 		addHeadlineKicker(cardOverrides, response.articles),
 	);
 

--- a/src/templates/csr/capi-single-paidfor/index.svelte
+++ b/src/templates/csr/capi-single-paidfor/index.svelte
@@ -50,7 +50,6 @@
 		position: relative;
 		display: flex;
 		flex-direction: column;
-
 		font-family: 'GuardianTextSans', 'Helvetica Neue', Helvetica, Arial,
 			'Lucida Grande', sans-serif;
 		font-kerning: normal;

--- a/src/templates/ssr/interscroller/index.svelte
+++ b/src/templates/ssr/interscroller/index.svelte
@@ -3,14 +3,17 @@
 </script>
 
 <div class="creative--interscroller">
+	<!-- svelte-ignore a11y-missing-attribute - no alt attribute needed for a pixel -->
 	<img
 		src="[%TrackingPixel%]"
 		class="creative__pixel creative__pixel--displayNone"
 	/>
+	<!-- svelte-ignore a11y-missing-attribute - no alt attribute needed for a pixel -->
 	<img
 		src="[%ResearchPixel%]"
 		class="creative__pixel creative__pixel--displayNone"
 	/>
+	<!-- svelte-ignore a11y-missing-attribute - no alt attribute needed for a pixel -->
 	<img
 		src="[%ViewabilityTracker%]"
 		class="creative__pixel creative__pixel--displayNone"

--- a/src/templates/ssr/manual-single/index.svelte
+++ b/src/templates/ssr/manual-single/index.svelte
@@ -72,7 +72,6 @@
 		max-width: 1300px;
 		display: flex;
 		flex-direction: column;
-
 		font-family: 'Guardian Text Egyptian', 'GuardianTextEgyptian', Georgia,
 			serif;
 		background-color: #f6f6f6;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Converts the CAPI Multiple Hosted template to Svelte. Each card is represented by the CapiHostedCard component. This is similar in many ways to the CapiCard component, but also has several key differences as well, so I have left them as two separate components for now.

- From the initial template, "kicker" and "numberOfElements" are no longer used, so I have removed them.
- The gaps between cards are now more consistent
- Adds a slight opacity on hover to give visual feedback to user
- Cards take up a bit more height between breakpoints, making using of responsive design

## Images

#### 360px
| Legacy | Svelte |
| - | - |
| ![legacy1] | ![svelte1] |

#### 425px
| Legacy | Svelte |
| - | - |
| ![legacy2] | ![svelte2] |

#### 740px
| Legacy | Svelte |
| - | - |
| ![legacy3] | ![svelte3] |

#### 980px
| Legacy | Svelte |
| - | - |
| ![legacy4] | ![svelte4] |

#### 1300px
| Legacy | Svelte |
| - | - |
| ![legacy5] | ![svelte5] |

[legacy1]: https://github.com/guardian/commercial-templates/assets/9574885/cc007c90-fcf4-4e70-8ef3-95ae87e85bff
[legacy2]: https://github.com/guardian/commercial-templates/assets/9574885/49efe419-d454-4626-b9a1-c4d04bfcf520
[legacy3]: https://github.com/guardian/commercial-templates/assets/9574885/63469c00-2d00-4fa5-bee4-f0a9583b25a8
[legacy4]: https://github.com/guardian/commercial-templates/assets/9574885/3cc62edb-41bc-404a-bdcf-5a296f0e357c
[legacy5]: https://github.com/guardian/commercial-templates/assets/9574885/3632a92d-c9b0-4d52-b537-89488cf5d828

[svelte1]: https://github.com/guardian/commercial-templates/assets/9574885/af75a9d3-cf2b-4889-8eae-08b73594db88
[svelte2]: https://github.com/guardian/commercial-templates/assets/9574885/94f41aae-a7bc-41ee-880e-bbac8a92ed44
[svelte3]: https://github.com/guardian/commercial-templates/assets/9574885/e5ba6104-1c11-4f92-8243-bf6ac3f83fd8
[svelte4]: https://github.com/guardian/commercial-templates/assets/9574885/a7c6356e-0d69-4079-9da7-dd2c4dd45b2d
[svelte5]: https://github.com/guardian/commercial-templates/assets/9574885/4bed7bb3-2f88-4d86-9cab-635d05973b04

### Accessibility

This template will now be easier to read for users that use a large font. These screenshots were taken using the "very large" font size in Chrome.

#### 360px
| Legacy | Svelte |
| - | - |
| ![legacyLarge1] | ![svelteLarge1] |

#### 740px
| Legacy | Svelte |
| - | - |
| ![legacyLarge2] | ![svelteLarge2] |

#### 1300px
| Legacy | Svelte |
| - | - |
| ![legacyLarge3] | ![svelteLarge3] |

[legacyLarge1]: https://github.com/guardian/commercial-templates/assets/9574885/9785c2e5-27be-4fe8-a77f-f89eb8bb2d59
[legacyLarge2]: https://github.com/guardian/commercial-templates/assets/9574885/45fc45d2-2408-4f72-b815-c4b8101c4ed8
[legacyLarge3]: https://github.com/guardian/commercial-templates/assets/9574885/eb1c9c3f-d464-4762-9ab2-8153af828df4

[svelteLarge1]: https://github.com/guardian/commercial-templates/assets/9574885/68495a09-c4b9-4076-9b07-62b6edfb7160
[svelteLarge2]: https://github.com/guardian/commercial-templates/assets/9574885/3b71cf4c-ae95-417a-8496-29f13c5df60a
[svelteLarge3]: https://github.com/guardian/commercial-templates/assets/9574885/77f066bb-be89-4eeb-8c8e-0af4466b3144