### PR TITLE
Update SeriesUrl variable name to match format

### DIFF
--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -13,7 +13,7 @@
 	import Resizer from '$templates/components/Resizer.svelte';
 	import { retrieveCapiData, addHeadlineKicker } from '$lib/capiMultiple';
 
-	export let SeriesUrl: GAMVariable;
+	export let SeriesURL: GAMVariable;
 	export let ComponentTitle: GAMVariable;
 	export let Article1Headline: GAMVariable;
 	export let Article1Image: GAMVariable;
@@ -60,7 +60,7 @@
 		},
 	];
 
-	const getCards = retrieveCapiData(cardOverrides, SeriesUrl).then((response) =>
+	const getCards = retrieveCapiData(cardOverrides, SeriesURL).then((response) =>
 		addHeadlineKicker(cardOverrides, response.articles),
 	);
 
@@ -70,14 +70,14 @@
 </script>
 
 {#await getCards}
-	<h3>Loading Content for “{SeriesUrl}”</h3>
+	<h3>Loading Content for “{SeriesURL}”</h3>
 {:then cards}
 	{#if cards[0]}
 		<aside bind:clientHeight={height}>
 			<PaidForHeader
 				edition={cards[0].branding.edition}
 				{ComponentTitle}
-				{SeriesUrl}
+				SeriesUrl= {SeriesURL}
 				templateType="multiple"
 			/>
 			<div class="body">
@@ -94,7 +94,7 @@
 		<Resizer {height} />
 	{/if}
 {:catch}
-	<h3>Could not fetch series “{SeriesUrl}”</h3>
+	<h3>Could not fetch series “{SeriesURL}”</h3>
 {/await}
 
 <style>

--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -77,7 +77,7 @@
 			<PaidForHeader
 				edition={cards[0].branding.edition}
 				{ComponentTitle}
-				SeriesUrl= {SeriesURL}
+				SeriesUrl={SeriesURL}
 				templateType="multiple"
 			/>
 			<div class="body">

--- a/src/templates/csr/capi-multiple-paidfor/test.json
+++ b/src/templates/csr/capi-multiple-paidfor/test.json
@@ -1,5 +1,5 @@
 {
-	"SeriesUrl": "renting-reinvented",
+	"SeriesURL": "renting-reinvented",
 	"ComponentTitle": "Renting Reinvented",
 	"Article1Headline": "Then, now and tomorrow – in pictures",
 	"Article1Image": "",


### PR DESCRIPTION
## What does this change?
The SeriesUrl variable has been updated to SeriesURL to match the native format. This means the native style should now update automatically via the GitHub Action. It failed on the previous merge because of this variable name mismatch.

<img width="886" alt="Screenshot 2024-01-09 at 15 22 26" src="https://github.com/guardian/commercial-templates/assets/108270776/9523af67-4efa-441c-bed5-ae9abd97ec39">
