### PR TITLE
Fix Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,8 +3,6 @@ name: Snyk
 
 on:
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,5 +14,8 @@ jobs:
       DEBUG: true
       ORG: guardian-commercial
       SKIP_NODE: false
+      SKIP_PYTHON: false
+      PYTHON_VERSION: 3.11
+      PIPFILES: scripts/deploy/Pipfile
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,6 +3,8 @@ name: Snyk
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
Snyk has been failing on main recently because it hasn't been set up for the new Python scripts for uploading to GAM. This PR adds the parameters we need to handle Python scripts and the Pipfile.

Tested by temporarily running Snyk on push to make sure it now runs successfully:

<img width="1111" alt="Screenshot 2024-01-09 at 17 00 39" src="https://github.com/guardian/commercial-templates/assets/108270776/3df28dc5-d9cd-44a7-bc99-e13459ecc627">

<img width="407" alt="Screenshot 2024-01-09 at 17 03 47" src="https://github.com/guardian/commercial-templates/assets/108270776/5b1d8b6f-0fc9-4dcc-92f5-3260fab97be4">
