### PR TITLE
Add clickMacro to card href

### DIFF
--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -4,6 +4,7 @@
 	import AudioIcon from './icons/AudioIcon.svelte';
 	import CameraIcon from './icons/CameraIcon.svelte';
 	import VideoIcon from './icons/VideoIcon.svelte';
+	import { clickMacro } from '$lib/gam';
 
 	export let templateType: 'single' | 'multiple';
 	export let single: Single;
@@ -25,7 +26,7 @@
 
 <a
 	class="{templateType}-card"
-	href={articleUrl}
+	href={clickMacro(articleUrl)}
 	style={`--direction: ${direction}`}
 >
 	<div class="media">


### PR DESCRIPTION
## What does this change?
Adds the clickMacro to the card href. At the moment the cards aren't linking to articles properly on the CAPI Multiple PaidFor template on the live site. Adding this clickMacro should resolve this.

You can see in the image below that the link currently opens within the ad iframe.

<img width="1467" alt="Screenshot 2024-01-10 at 14 38 58" src="https://github.com/guardian/commercial-templates/assets/108270776/7e83c8f5-a086-4fa5-a9cb-ef1d9eb5f15d">
