### PR TITLE
Add target="_top" for manual cards

### DIFF
--- a/src/templates/components/ManualCard.svelte
+++ b/src/templates/components/ManualCard.svelte
@@ -16,7 +16,12 @@
 	export let isProminent = false;
 </script>
 
-<a class="card" class:is-prominent={isProminent} href={clickMacro(url)}>
+<a
+	class="card"
+	class:is-prominent={isProminent}
+	href={clickMacro(url)}
+	target="_top"
+>
 	<div class="media">
 		<picture>
 			<img src={image} alt="" />


### PR DESCRIPTION
## What does this change?
Manual cards currently navigate to links inside the iframe when clicked, when they should be using the whole window (see GIF). Adding target="_top" should resolve this.

![Screen Recording 2024-01-11 at 15 43 15](https://github.com/guardian/commercial-templates/assets/108270776/b0e61a8b-6667-4df7-b031-e1c1d95ce663)
