### PR TITLE
Set min-height for CapiCard images to 80px

### DIFF
--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -49,7 +49,7 @@
 						sizes={source.sizes}
 					/>
 				{/each}
-				<img src={articleImage.backupSrc} alt="" style="min-height: 80px" />
+				<img src={articleImage.backupSrc} alt="" />
 			</picture>
 		{:else}
 			<img src={articleImage.backupSrc} alt="" />
@@ -126,6 +126,7 @@
 	img {
 		display: block;
 		width: 100%;
+		min-height: 80px;
 	}
 
 	a.single-card .text {

--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -49,7 +49,7 @@
 						sizes={source.sizes}
 					/>
 				{/each}
-				<img src={articleImage.backupSrc} alt="" style="min-height: 80px"/>
+				<img src={articleImage.backupSrc} alt="" style="min-height: 80px" />
 			</picture>
 		{:else}
 			<img src={articleImage.backupSrc} alt="" />

--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -49,7 +49,7 @@
 						sizes={source.sizes}
 					/>
 				{/each}
-				<img src={articleImage.backupSrc} alt="" />
+				<img src={articleImage.backupSrc} alt="" style="min-height: 80px"/>
 			</picture>
 		{:else}
 			<img src={articleImage.backupSrc} alt="" />


### PR DESCRIPTION
## What does this change?
Adds a min-height of 80px for images in the Capi Card. Having observed different breakpoints, I can't see any images loading with a height of less than 96px, so this should be a safe value.

We noticed that on the first page load for a CAPI Multiple PaidFor ad on the site, the iframe doesn't load in a big enough size for the ad to show. On subsequent page views it then seems to behave as expected. (Open a lifestyle article in incognito mode to replicate this). The legacy template set min-heights on the images, so we're adding a min-height to images to see if this is the cause of the behaviour or not.

Example of iframe not loading to correct size:
<img width="1381" alt="Screenshot 2024-01-15 at 12 51 07" src="https://github.com/guardian/commercial-templates/assets/108270776/cf374c45-9d44-4581-92d2-28d42c5d5b16">
