### PR TITLE
Fix Resizer bug and minor style tweak

### DIFF
--- a/src/lib/Previews.svelte
+++ b/src/lib/Previews.svelte
@@ -48,6 +48,7 @@
 
 			switch (data.type) {
 				case 'set-ad-height':
+				case 'resize':
 					const iframe = source.frameElement as HTMLIFrameElement;
 					iframe.height = String(data.value.height);
 					break;

--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -103,16 +103,6 @@
 		background-color: #e4e4e4;
 	}
 
-	a.multiple-card:not(:first-of-type)::before {
-		content: '';
-		position: absolute;
-		top: 119px;
-		bottom: 102px;
-		margin-left: -10px;
-		width: 1px;
-		background: #dcdcdc;
-	}
-
 	a.single-card .media {
 		margin: -10px;
 	}
@@ -192,12 +182,28 @@
 			margin: 12px 10px;
 		}
 
+		a.multiple-card:not(:first-of-type)::before {
+			content: '';
+			position: absolute;
+			top: 78px;
+			bottom: 102px;
+			margin-left: -10px;
+			width: 1px;
+			background: #dcdcdc;
+		}
+
 		a.multiple-card:nth-child(n) {
 			display: block;
 		}
 
 		a.multiple-card .text h2 {
 			margin-bottom: 10px;
+		}
+	}
+
+	@media (min-width: 980px) {
+		a.multiple-card:not(:first-of-type)::before {
+			top: 131px;
 		}
 	}
 

--- a/src/templates/components/Resizer.svelte
+++ b/src/templates/components/Resizer.svelte
@@ -3,5 +3,5 @@
 
 	export let height: number;
 
-	$: post({ type: 'set-ad-height', value: { height, width: -1 } });
+	$: post({ type: 'resize', value: { height } });
 </script>

--- a/src/templates/components/SetHeightResizer.svelte
+++ b/src/templates/components/SetHeightResizer.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { post } from '$lib/messenger';
+
+	export let height: number;
+
+	$: post({ type: 'set-ad-height', value: { height, width: -1 } });
+</script>

--- a/src/templates/csr/capi-single-paidfor/index.svelte
+++ b/src/templates/csr/capi-single-paidfor/index.svelte
@@ -12,7 +12,7 @@
 	import CapiCard from '$templates/components/CapiCard.svelte';
 	import PaidForHeader from '$templates/components/PaidForHeader.svelte';
 	import { addTrackingPixel, isValidReplacedVariable } from '$lib/gam';
-	import Resizer from '$templates/components/Resizer.svelte';
+	import SetHeightResizer from '$templates/components/SetHeightResizer.svelte';
 
 	export let SeriesUrl: GAMVariable;
 	export let ComponentTitle: GAMVariable;
@@ -39,7 +39,7 @@
 		/>
 		<CapiCard templateType="single" {single} />
 	</aside>
-	<Resizer {height} />
+	<SetHeightResizer {height} />
 {:catch}
 	<h3>Could not fetch series “{SeriesUrl}”</h3>
 {/await}

--- a/src/templates/csr/events-multiple/index.svelte
+++ b/src/templates/csr/events-multiple/index.svelte
@@ -2,10 +2,10 @@
 	import type { GAMVariable } from '$lib/gam';
 	import '$templates/components/fonts/Sans.css';
 	import ManualCard from '$templates/components/ManualCard.svelte';
-	import Resizer from '$templates/components/Resizer.svelte';
 	import ManualHeader from '$templates/components/ManualHeader.svelte';
 	import ToneLogo from '$templates/components/ToneLogo.svelte';
 	import type { Tone } from '$lib/types/tones';
+	import SetHeightResizer from '$templates/components/SetHeightResizer.svelte';
 
 	export let BannerDescription: GAMVariable;
 	export let HeaderButtonText: GAMVariable;
@@ -89,7 +89,7 @@
 		{/each}
 	</div>
 </aside>
-<Resizer {height} />
+<SetHeightResizer {height} />
 
 <style lang="scss">
 	aside {

--- a/src/templates/csr/manual-multiple/index.svelte
+++ b/src/templates/csr/manual-multiple/index.svelte
@@ -3,9 +3,9 @@
 	import '$templates/components/fonts/Sans.css';
 	import ManualCard from '$templates/components/ManualCard.svelte';
 	import ManualHeader from '$templates/components/ManualHeader.svelte';
-	import Resizer from '$templates/components/Resizer.svelte';
 	import ToneLogo from '$templates/components/ToneLogo.svelte';
 	import type { Tone } from '$lib/types/tones';
+	import SetHeightResizer from '$templates/components/SetHeightResizer.svelte';
 
 	export let Tone: GAMVariable<Tone>;
 	export let TitleURL: GAMVariable;
@@ -92,7 +92,7 @@
 		{/each}
 	</div>
 </aside>
-<Resizer {height} />
+<SetHeightResizer {height} />
 
 <style lang="scss">
 	aside {


### PR DESCRIPTION
## What does this change?
A number of changes:
- Changes the Resizer message from `set-ad-height` to `resize` as we think Messenger wasn't receiving the set-ad-height message in a valid form and so no resize took place
- Keeps the old Resizer logic in a renamed component. We don't want this update to negatively affect existing templates without the slow network resize bug, so we've kept the old logic for the templates I didn't test on GAM. We can revisit this in future but it's more important to get the bug fixed now.
- Adds local handling for the resize post message so that Preview containers resize correctly
- Changes the dividing line heights for the CAPI Multiple PaidFor template as I noticed they were a bit off when testing. Images below.

### Incorrect dividing lines
![Screenshot 2024-01-18 at 16 57 14](https://github.com/guardian/commercial-templates/assets/108270776/d258a1cd-a930-4972-90d2-56db8e5d5407)

### Fixed dividing lines
![Screenshot 2024-01-18 at 16 56 59](https://github.com/guardian/commercial-templates/assets/108270776/9a990658-e277-4d50-8424-3306c2db67d9)

## How to test
I've tested this by throttling the network connection and using a test creative in an adtest. The adtest is `svelte-resizer` if you'd like to check it, but I'll likely deactivate the test creative tomorrow.

