### PR TITLE
FIX: Creative opening url in the same iframe

### DIFF
--- a/src/templates/ssr/fabric-custom/index.svelte
+++ b/src/templates/ssr/fabric-custom/index.svelte
@@ -9,6 +9,7 @@
 	export let thirdPartyJSTracking: GAMVariable;
 </script>
 
+<base target="_blank">
 <div id="creative">
 	<AdvertisementLabel />
 	<a id="creative-link" href={clickMacro(DEST_URL)}> </a>

--- a/src/templates/ssr/fabric-custom/index.svelte
+++ b/src/templates/ssr/fabric-custom/index.svelte
@@ -9,7 +9,7 @@
 	export let thirdPartyJSTracking: GAMVariable;
 </script>
 
-<base target="_blank">
+<base target="_blank" />
 <div id="creative">
 	<AdvertisementLabel />
 	<a id="creative-link" href={clickMacro(DEST_URL)}> </a>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creative opening url in the same iframe, adding base with a target of _blank is needed.
![creative-opening-iniframe](https://github.com/guardian/commercial-templates/assets/371350/e02377e9-a4d8-43c4-a704-8851cff8f497)


## How to test

Running preview locally clicking banner will open a new window.


