### PR TITLE
Preventing deployment by removing ad.json to look at JS issue

### DIFF
--- a/src/templates/ssr/fabric-custom/ad.json
+++ b/src/templates/ssr/fabric-custom/ad.json
@@ -1,3 +1,0 @@
-{
-	"nativeStyleId": "119639"
-}


### PR DESCRIPTION
In some custom fabrics we run JS. On legacy it runs, but on the svelte version it doesn't.

Can be tested locally by switching dapAssets parameter to a custom with JS


Example 

DAP_Hilton_standard_dec23

That will start animating in legacy, but not in the svelte preview because the animate class is not added.

Script tag is being added and doesn't look malformed.

