### PR TITLE
Fix fabric custom script tags

### DIFF
--- a/src/templates/ssr/fabric-custom/index.ts
+++ b/src/templates/ssr/fabric-custom/index.ts
@@ -23,9 +23,24 @@ const getTag = () => {
 	return Promise.reject('No tag found');
 };
 
+/**
+ * This is a hack to insert the html into the DOM,
+ * using innerHtml would not work if the tag contains a script tag
+ * see https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations
+ *
+ * @param tag the html to insert
+ */
+const insertTag = (tag: string) => {
+	const placeholder = document.getElementById('creative-link')!;
+	const range = document.createRange();
+	range.setStart(placeholder, 0);
+	range.setEnd(placeholder, 0);
+	placeholder.appendChild(range.createContextualFragment(tag));
+};
+
 getTag()
 	.then((tag) => {
-		document.getElementById('creative-link')!.innerHTML = tag;
+		insertTag(tag);
 		post({
 			type: 'resize',
 			value: { height: document.getElementById('creative')!.offsetHeight },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
script tags in fabric customs weren't running, this was due to a browser security feature that causes script tags inserted via `innerHTML` not to run without any errors or warnings. See https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations

The legacy templates used some sort of hack to get around this, which will still work with svelte.
