### PR TITLE
Amend logic for hosted advertiser logo

### DIFF
--- a/src/lib/capiMultiple.ts
+++ b/src/lib/capiMultiple.ts
@@ -29,7 +29,7 @@ function addCapiHostedCardOverrides(
 	overrideCards: CapiCardOverride[],
 	overrideLogo?: string,
 ): { logo: string | null; cards: CapiHostedCard[] } {
-	const logo = overrideLogo ?? cardData[0]?.branding.logo.src;
+	const logo = overrideLogo ? overrideLogo : cardData[0]?.branding.logo.src;
 	return {
 		logo: logo ?? null,
 		cards: cardData


### PR DESCRIPTION
## What does this change?
The advertiser logo was missing from the hosted template. This is because we were using the [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) operator. The left hand operand should be `null` or `undefined` to return the right hand side. An empty string is falsy but not null, so we were returning an empty string as the logo. I've switched to using a ternary operator, which checks for a falsy value instead.

### Before:

<img width="1342" alt="Screenshot 2024-02-23 at 14 52 14" src="https://github.com/guardian/commercial-templates/assets/108270776/22517256-632c-4419-a061-63f8b9338a42">

### After:

<img width="1331" alt="Screenshot 2024-02-23 at 14 51 14" src="https://github.com/guardian/commercial-templates/assets/108270776/b9a0b47f-b57c-4775-8ae6-992ff7cf5957">
