### PR TITLE
Don't show HTML and CSS by default

### DIFF
--- a/src/lib/Code.svelte
+++ b/src/lib/Code.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	export let html: string;
 	export let css: string;
+	export let showHTML = false;
+	export let showCSS = false;
 </script>
 
 <section id="code">
@@ -8,11 +10,29 @@
 
 	<div class="html">
 		<h2>HTML</h2>
-		<pre>{html}</pre>
+		<button on:click={() => (showHTML = !showHTML)}>
+			{#if showHTML}
+				Hide HTML
+			{:else}
+				Show HTML
+			{/if}
+		</button>
+		{#if showHTML}
+			<pre>{html}</pre>
+		{/if}
 	</div>
 	<div>
 		<h2>CSS</h2>
-		<pre>{css}</pre>
+		<button on:click={() => (showCSS = !showCSS)}>
+			{#if showCSS}
+				Hide CSS
+			{:else}
+				Show CSS
+			{/if}
+		</button>
+		{#if showCSS}
+			<pre>{css}</pre>
+		{/if}
 	</div>
 </section>
 
@@ -30,5 +50,15 @@
 
 	h3 {
 		grid-column: span 2;
+	}
+
+	button {
+		color: white;
+		border: 2px solid darkblue;
+		background-color: darkblue;
+		border-radius: 15px;
+		font-size: 1rem;
+		font-family: inherit;
+		padding: 5px 10px;
 	}
 </style>

--- a/src/lib/Code.svelte
+++ b/src/lib/Code.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { slide } from "svelte/transition";
+
 	export let html: string;
 	export let css: string;
 	export let showHTML = false;
@@ -11,14 +13,10 @@
 	<div class="html">
 		<h2>HTML</h2>
 		<button on:click={() => (showHTML = !showHTML)}>
-			{#if showHTML}
-				Hide HTML
-			{:else}
-				Show HTML
-			{/if}
+			{showHTML ? 'Hide HTML' : 'Show HTML'}
 		</button>
 		{#if showHTML}
-			<pre>{html}</pre>
+			<pre transition:slide>{html}</pre>
 		{/if}
 	</div>
 	<div>
@@ -31,7 +29,7 @@
 			{/if}
 		</button>
 		{#if showCSS}
-			<pre>{css}</pre>
+			<pre transition:slide>{css}</pre>
 		{/if}
 	</div>
 </section>

--- a/src/lib/Code.svelte
+++ b/src/lib/Code.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { slide } from "svelte/transition";
+	import { slide } from 'svelte/transition';
 
 	export let html: string;
 	export let css: string;


### PR DESCRIPTION
## What does this change?
At the moment, on each template page we show the full HTML and CSS for the template underneath. This is left over from when we had to manually copy the HTML and CSS into the templates in GAM. Now that we don't need to do that, it looks nicer to hide it by default, but it's still easily accessible behind a button.

This change is also a pre-requisite for visual regression testing, as having the HTML and CSS written out is a very common cause of false positives.

### Before:
<img width="1335" alt="Screenshot 2024-04-19 at 15 01 15" src="https://github.com/guardian/commercial-templates/assets/108270776/8d0ff49d-af22-4d76-a526-95e00d29b0f6">


### After:
<img width="933" alt="Screenshot 2024-04-19 at 14 53 18" src="https://github.com/guardian/commercial-templates/assets/108270776/ff1683ba-a862-4c24-8ff9-e8f8a046abda">

<img width="1402" alt="Screenshot 2024-04-19 at 14 53 28" src="https://github.com/guardian/commercial-templates/assets/108270776/ca42a3e0-9477-403b-b198-568409a62c62">
