### PR TITLE
Fix fabric margins on Firefox

### DIFF
--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -102,6 +102,7 @@
 <style lang="scss">
 	:global(body) {
 		background-color: var(--background-color);
+		margin: 0;
 	}
 
 	.fabric-container {


### PR DESCRIPTION
## What does this change?
We had a bug in some of our templates a while ago where Firefox adds default padding to the templates, making them get pushed down a little. For some reason, Chrome and Firefox have different default rendering behaviour for the HTML body element in an iframe. I think the fix got missed in the migration, so this bug got reintroduced. See screenshots:

How fabrics currently appear on Firefox (note margin above ad label):
<img width="1336" alt="Screenshot 2024-04-29 at 17 19 23" src="https://github.com/guardian/commercial-templates/assets/108270776/e42c0fc2-74e8-4c8d-819f-6db93c39f883">

How they should look:
<img width="1313" alt="Screenshot 2024-04-29 at 17 27 44" src="https://github.com/guardian/commercial-templates/assets/108270776/864d290c-cbd6-4c2b-ab52-60a8f6a808eb">
