### PR TITLE
Add target = _top to labs logo link

### DIFF
--- a/src/templates/components/icons/GuardianLabs.svelte
+++ b/src/templates/components/icons/GuardianLabs.svelte
@@ -14,7 +14,7 @@
 	export let edition: Single['branding']['edition'] = 'UK';
 </script>
 
-<a href={`${CLICK_MACRO}${host}/${GLABS_EDITIONS[edition]}`}>
+<a href={`${CLICK_MACRO}${host}/${GLABS_EDITIONS[edition]}`} target="_top">
 	<svg aria-hidden="true" width="100" height="50" viewBox="0 0 100 50" {fill}>
 		<title>The Guardian Labs</title>
 


### PR DESCRIPTION
## What does this change?
When a reader clicks on the labs logo it currently opens up the link in the same iframe. Adding `target=_top` to a a tag should mean the link opens up correctly when clicked.

## How to test
Tested locally with a recent labs campaign link.

### Before

https://github.com/guardian/commercial-templates/assets/108270776/c4833919-ffed-4f5d-a0e8-f0fc74fa10e4


### After

https://github.com/guardian/commercial-templates/assets/108270776/ccc64626-2f9c-414e-ab9c-0ef45c6fb3ef


