### PR TITLE
Fix fabric-custom tracking pixel

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,7 @@ module.exports = {
 	},
 	env: {
 		browser: true,
-		es2017: true,
+		es2020: true,
 		node: true,
 	},
 	overrides: [

--- a/src/templates/components/Pixel.svelte
+++ b/src/templates/components/Pixel.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { isValidReplacedVariable } from '$lib/gam';
 
+	if (!('window' in globalThis)) {
+		throw new Error("Don't use the <Pixel /> component in SSR templates");
+	}
+
 	export let src: string;
 </script>
 

--- a/src/templates/ssr/fabric-custom/index.svelte
+++ b/src/templates/ssr/fabric-custom/index.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import { clickMacro, DEST_URL, type GAMVariable } from '$lib/gam';
 	import AdvertisementLabel from '$templates/components/AdvertisementLabel.svelte';
-	import Pixel from '$templates/components/Pixel.svelte';
 
-	export let TrackingPixel: GAMVariable;
-	export let ResearchPixel: GAMVariable;
 	export let ViewabilityTracker: GAMVariable;
 	export let thirdPartyJSTracking: GAMVariable;
 </script>
@@ -14,8 +11,6 @@
 	<AdvertisementLabel />
 	<a id="creative-link" href={clickMacro(DEST_URL)}> </a>
 </div>
-<Pixel src={TrackingPixel} />
-<Pixel src={ResearchPixel} />
 {@html ViewabilityTracker}
 {@html thirdPartyJSTracking}
 

--- a/src/templates/ssr/fabric-custom/index.ts
+++ b/src/templates/ssr/fabric-custom/index.ts
@@ -6,8 +6,8 @@ const DapAssetsFolder: string = '[%DapAssetsFolder%]';
 
 const DapAssetsPath = `${DapAssetsRoot}/${DapAssetsFolder}`;
 const ThirdPartyTag: string = '[%ThirdPartyTag%]';
-const TrackingPixel: string | undefined = '[%TrackingPixel%]';
-const ResearchPixel: string | undefined = '[%ResearchPixel%]';
+const TrackingPixel: string = '[%TrackingPixel%]';
+const ResearchPixel: string = '[%ResearchPixel%]';
 
 const addTrackingPixel = (url: string) => {
 	const pixel = new Image();

--- a/src/templates/ssr/fabric-custom/index.ts
+++ b/src/templates/ssr/fabric-custom/index.ts
@@ -1,10 +1,18 @@
 import { post } from '$lib/messenger';
 
+const CACHE_BUST = '%%CACHEBUSTER%%';
 const DapAssetsRoot = `https://s3-eu-west-1.amazonaws.com/adops-assets/dap-fabrics`;
 const DapAssetsFolder: string = '[%DapAssetsFolder%]';
 
 const DapAssetsPath = `${DapAssetsRoot}/${DapAssetsFolder}`;
 const ThirdPartyTag: string = '[%ThirdPartyTag%]';
+const TrackingPixel: string | undefined = '[%TrackingPixel%]';
+const ResearchPixel: string | undefined = '[%ResearchPixel%]';
+
+const addTrackingPixel = (url: string) => {
+	const pixel = new Image();
+	pixel.src = url + CACHE_BUST;
+};
 
 // relative paths in the CSS need to be replaced with the absolute path
 const replaceAssetLinks = (html: string) => {
@@ -49,3 +57,11 @@ getTag()
 	.catch((e) => {
 		console.error(e);
 	});
+
+if (TrackingPixel) {
+	addTrackingPixel(TrackingPixel);
+}
+
+if (ResearchPixel) {
+	addTrackingPixel(ResearchPixel);
+}


### PR DESCRIPTION
## What does this change?
The `Pixel` component won't work in an SSR component because the [`isValidReplacedVariable`](https://github.com/guardian/commercial-templates/pull/382/files#diff-112bfaccb078632e0383ee5103c3360f7ed59e87ebfc5c543079a469287f88a1L7) used there will cause the `img` element to never render during SSR.

I've moved the pixel code to the `index.ts` and added a guard to the `Pixel` component to prevent it being used in an SSR component in future.