### PR TITLE
Create new test template for Public Good

### DIFF
--- a/src/templates/csr/public-good-test/ad.json
+++ b/src/templates/csr/public-good-test/ad.json
@@ -1,0 +1,3 @@
+{
+	"nativeStyleId": "844854"
+}

--- a/src/templates/csr/public-good-test/index.svelte
+++ b/src/templates/csr/public-good-test/index.svelte
@@ -18,7 +18,7 @@
 		const consentState = await getUSPData();
 
 		if (!consentState || isCcpaOptedOut(consentState)) {
-			!consentState && console.error('No consent state found');
+			!consentState && console.error('No consent');
 
 			return refresh();
 		}

--- a/src/templates/csr/public-good-test/index.svelte
+++ b/src/templates/csr/public-good-test/index.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { getUSPData, isCcpaOptedOut } from '$lib/cmp';
+	import { post } from '$lib/messenger';
+	import { getPageURL } from '$lib/messenger/get-page-url';
+	import { create, type PgmApiOptions } from '$lib/public-good';
+
+	let container: HTMLElement;
+
+	const refresh = () =>
+		post({
+			type: 'passback-refresh',
+			value: 'public-good',
+		});
+
+	const onload = async () => {
+		let url = await getPageURL();
+
+		const consentState = await getUSPData();
+
+		if (!consentState || isCcpaOptedOut(consentState)) {
+			!consentState && console.error('No consent state found');
+
+			return refresh();
+		}
+
+		if (!url) {
+			console.error('No URL found');
+			return refresh();
+		}
+		const options: PgmApiOptions = {
+			partnerId: 'gmg-guardian',
+			attributes: {
+				url,
+			},
+			onHide: refresh,
+		};
+
+		create(container, options);
+	};
+</script>
+
+<svelte:head>
+	<script
+		type="text/javascript"
+		src="https://assets.publicgood.com/pgm/v1/dpg.js"
+		on:load={onload}
+	></script>
+</svelte:head>
+<div
+	id="public-good"
+	class="pgs-dpg-flex"
+	data-pgs-partner-id="gmg"
+	data-pgs-target-id="db973434-8db2-4293-9485-45ba5b591416"
+	data-pgs-target-type="campaign"
+	bind:this={container}
+/>
+
+<style lang="scss">
+	#public-good {
+		width: 100%;
+		height: 465px;
+	}
+</style>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR adds a new test for Public Good. A new template named `public-good-test` is created with the new integration as requested by US and Public Good. Check [ticket](https://trello.com/c/MR25vjOO/2949-create-a-new-test-template-for-public-good) for more details and to check the new integration. 

I added the `nativeStyleId` for this native test https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=844854&tab=ad_settings but this `id` will be changed when we have a PROD Public Good with this new template. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Public Good is served in the `article-end` slot when Reader Revenue epic doesn't show up and it's only served in US so using a VPN is a must to test and add at the end of the article url `?adtest=comm-dev-public-good-test`

## Images

- The new data attributes which doesn't exist in Public Good 

![image](https://github.com/guardian/commercial-templates/assets/23424805/d0e8af56-b95e-403f-95f0-8a8d35f11bac)


- Different height comparing to the Public Good

![image](https://github.com/guardian/commercial-templates/assets/23424805/af67fea5-4267-4eb1-8f5e-5585e0ac0801)







