### PR TITLE
Add PR comment with visual test results

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@ node_modules
 svelte.config.js
 playwright.config.ts
 /playwright
+/scripts
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -49,8 +49,8 @@ jobs:
           script: |
             const { readFileSync, resolve } = require('fs');
             const resultsTable = readFileSync('./test-results/visual-regression-results-table.txt', 'utf8');
-            const body = `### Visual regression testing results
-            Please check that any visual changes in the failing tests are intentional before merging your PR.
+            const body = `### Visual regression testing results 🔍
+            If any tests are failing, please check that any visual changes are intentional before merging your PR.
 
             ${resultsTable}`
             if (context.eventName === 'pull_request') {

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: write-all
+
 jobs:
   test:
     name: Visual regression

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -50,8 +50,9 @@ jobs:
             const { readFileSync, resolve } = require('fs');
             const resultsTable = readFileSync('./test-results/visual-regression-results-table.txt', 'utf8');
             const body = `### Visual regression testing results
-            ${resultsTable}
-            Please check that any visual changes in the failing tests are intentional before merging your PR.`
+            Please check that any visual changes in the failing tests are intentional before merging your PR.
+
+            ${resultsTable}`
             if (context.eventName === 'pull_request') {
               const comments = await github.rest.issues.listComments({
                 issue_number: context.issue.number,

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -36,3 +36,37 @@ jobs:
 
       - name: Run Playwright
         run: pnpm playwright test
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { readFileSync, resolve } = require('fs');
+            const resultsTable = readFileSync('./test-results/visual-regression-results-table.txt', 'utf8');
+            const body = `### Visual regression testing results
+            ${resultsTable}
+            Please check that any visual changes in the failing tests are intentional before merging your PR.`
+            if (context.eventName === 'pull_request') {
+              const comments = await github.rest.issues.listComments({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              const existingComment = comments.data.find(comment => comment.body.includes('Visual regression testing results'));
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  comment_id: existingComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                });
+                return;
+              } else {
+                const { data } = await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                });
+              }
+            }

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -35,7 +35,11 @@ jobs:
         run: pnpm dev & npx wait-on -v -i 1000 http://localhost:7777
 
       - name: Run Playwright
+        continue-on-error: true
         run: pnpm playwright test
+
+      - name: Construct results table
+        run: node scripts/analyse-visual-results
 
       - uses: actions/github-script@v7
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,10 @@ const config: PlaywrightTestConfig = {
 	],
 	testDir: './playwright',
 	snapshotPathTemplate: '{testDir}/reference-images/{arg}{ext}',
+	reporter: [
+		['line'],
+		['json', { outputFile: 'test-results/visual-regression-results.json' }],
+	],
 };
 
 export default config;

--- a/playwright/fabric-custom.test.ts
+++ b/playwright/fabric-custom.test.ts
@@ -45,7 +45,7 @@ test.describe('Fabric Custom', () => {
 			// compare screenshot to reference
 			await expect(testTemplateLocator).toHaveScreenshot(
 				`Fabric-custom-${width.replace('%', '')}.png`,
-				{ animations: 'disabled', maxDiffPixelRatio: 0.004 },
+				{ animations: 'disabled', maxDiffPixelRatio: 0.006 },
 			);
 		}
 	});

--- a/playwright/fabric-custom.test.ts
+++ b/playwright/fabric-custom.test.ts
@@ -3,7 +3,7 @@ import { localBaseUrl, referenceBaseUrl, templatePreviewWidths } from './utils';
 
 const viewport = { width: 1600, height: 1000 };
 
-test.describe('Fabric Custom visual regression testing', () => {
+test.describe('Fabric Custom', () => {
 	test('Get reference screenshots', async ({ page }) => {
 		await page.setViewportSize(viewport);
 

--- a/playwright/manual-multiple.test.ts
+++ b/playwright/manual-multiple.test.ts
@@ -44,7 +44,7 @@ test.describe('Manual Multiple', () => {
 			// compare screenshot to reference
 			await expect(testTemplateLocator).toHaveScreenshot(
 				`Manual-multiple-${width.replace('%', '')}.png`,
-				{ maxDiffPixelRatio: 0.004 },
+				{ maxDiffPixelRatio: 0.006 },
 			);
 		}
 	});

--- a/playwright/manual-multiple.test.ts
+++ b/playwright/manual-multiple.test.ts
@@ -3,7 +3,7 @@ import { localBaseUrl, referenceBaseUrl, templatePreviewWidths } from './utils';
 
 const viewport = { width: 1600, height: 1000 };
 
-test.describe('Manual Multiple visual regression testing', () => {
+test.describe('Manual Multiple', () => {
 	test('Get reference screenshots', async ({ page }) => {
 		await page.setViewportSize(viewport);
 

--- a/playwright/manual-single.test.ts
+++ b/playwright/manual-single.test.ts
@@ -44,7 +44,7 @@ test.describe('Manual Single', () => {
 			// compare screenshot to reference
 			await expect(testTemplateLocator).toHaveScreenshot(
 				`Manual-single-${width.replace('%', '')}.png`,
-				{ maxDiffPixelRatio: 0.004 },
+				{ maxDiffPixelRatio: 0.006 },
 			);
 		}
 	});

--- a/playwright/manual-single.test.ts
+++ b/playwright/manual-single.test.ts
@@ -3,7 +3,7 @@ import { localBaseUrl, referenceBaseUrl, templatePreviewWidths } from './utils';
 
 const viewport = { width: 1600, height: 1000 };
 
-test.describe('Manual Single visual regression testing', () => {
+test.describe('Manual Single', () => {
 	test('Get reference screenshots', async ({ page }) => {
 		await page.setViewportSize(viewport);
 

--- a/scripts/analyse-visual-results.js
+++ b/scripts/analyse-visual-results.js
@@ -1,0 +1,29 @@
+import { readFileSync, writeFileSync } from 'fs';
+import path, { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+// replicate __dirname functionality as this is an es module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const filePath = resolve(
+	__dirname,
+	`../test-results/visual-regression-results.json`,
+);
+const fileContent = JSON.parse(readFileSync(filePath, 'utf-8'));
+
+const tests = fileContent.suites;
+
+let resultsTable = `| Template | Visual test status |
+| ------------- | ------------- |`;
+
+for (const test of tests) {
+	const testStatus = Boolean(test.suites[0].specs[1].ok);
+	const testTitle = test.suites[0].title;
+	resultsTable += `\n| ${testTitle} | ${testStatus ? '✅' : '❌'} |`;
+}
+
+writeFileSync(
+	resolve(__dirname, `../test-results/visual-regression-results-table.txt`),
+	resultsTable,
+);


### PR DESCRIPTION
## What does this change?
Updates the way that visual regression testing works to improve the developer experience. The visual regression test action no longer fails if there are visual changes, to reflect the fact that these may be intentional. Instead, a comment is added to the pull request to indicate if tests are failing, and for which templates.


<img width="923" alt="Screenshot 2024-08-09 at 12 48 09" src="https://github.com/user-attachments/assets/7ff15a23-1f0e-4fca-a325-07a27fdcc035">

