### PR TITLE
Interscroller: Adding JS  tracking field

### DIFF
--- a/src/templates/ssr/interscroller/index.svelte
+++ b/src/templates/ssr/interscroller/index.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { type GAMVariable } from '$lib/gam';
+
 	export let thirdPartyJSTracking: GAMVariable;
 </script>
 

--- a/src/templates/ssr/interscroller/index.svelte
+++ b/src/templates/ssr/interscroller/index.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { type GAMVariable } from '$lib/gam';
+	export let thirdPartyJSTracking: GAMVariable;
 </script>
 
 <div class="creative--interscroller">
@@ -20,6 +22,7 @@
 		class="creative__pixel creative__pixel--displayNone"
 		aria-hidden="true"
 	/>
+	{@html thirdPartyJSTracking}
 </div>
 
 <style lang="scss">
@@ -31,3 +34,4 @@
 		display: none;
 	}
 </style>
+

--- a/src/templates/ssr/interscroller/index.svelte
+++ b/src/templates/ssr/interscroller/index.svelte
@@ -34,4 +34,3 @@
 		display: none;
 	}
 </style>
-


### PR DESCRIPTION

## What does this change?
Adops have a requested that we have the JS tracking field added to the interscroller format, bringing it in to line with the fabrics.



## How to test

Ad test was created, adops supplied a tag.

https://www.theguardian.com/games/article/2024/aug/21/atomfall-nuclear-catastrophe-lake-district-fallout?adtest=tracking_test

https://admanager.google.com/59666047#creatives/creative/detail/line_item_id=6772751927&creative_id=138486993391

## How can we measure success?

I can see the tag attached and see it firing via the network tab.


![Screenshot 2024-08-21 at 15 08 57](https://github.com/user-attachments/assets/2396bd5b-3cd9-412c-b6a3-bca691a7b196)

![Screenshot 2024-08-21 at 15 09 05](https://github.com/user-attachments/assets/b493dea3-b4e8-4896-a617-264174109b0a)
