### PR TITLE
Default to width: auto for CAPI Multiple Paid For template

### DIFF
--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -132,6 +132,10 @@
 		color: white;
 	}
 
+	div {
+		width: auto;
+	}
+
 	@media (min-width: 740px) {
 		.cards-container {
 			flex-direction: row;


### PR DESCRIPTION
## What does this change?
In opt-out, the CAPI Multiple Paid For template is inheriting a default width of 100% for divs, which is breaking the template styling. Explicitly setting a default of `width: auto` fixes these styling issues.

### Before:
<img width="1061" alt="Screenshot 2024-10-02 at 15 15 09" src="https://github.com/user-attachments/assets/211ef6c9-ae0b-4d03-b4e0-1fd7f9821c23">


### After
<img width="1059" alt="Screenshot 2024-10-02 at 15 15 19" src="https://github.com/user-attachments/assets/06391bda-74af-4f0f-afe3-46b916079a73">
