### PR TITLE
Fix error message for husky post-merge

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -17,6 +17,7 @@ fi
 
 if [[ ! -z $changedLock ]]
 then
+	corepack enable pnpm
 	echo "${RED}This application has updated dependencies. Installing with pnpm...${ENDCOLOR}"
 	pnpm install --frozen-lockfile
 fi


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

When I pulled the latest changes in this repo I expected the changed dependencies to automatically be installed but instead I got this error. 

![Screenshot 2024-12-13 at 10 20 18](https://github.com/user-attachments/assets/441c1337-802b-4d88-a681-b6227bea5b33)

This PR fixes this issue by adding `corepack enable pnpm` to husky _post-merge_ hook.
