### PR TITLE
remove ThirdPartyTag from custom templates

### DIFF
--- a/src/templates/ssr/fabric-custom/index.ts
+++ b/src/templates/ssr/fabric-custom/index.ts
@@ -5,7 +5,6 @@ const DapAssetsRoot = `https://s3-eu-west-1.amazonaws.com/adops-assets/dap-fabri
 const DapAssetsFolder: string = '[%DapAssetsFolder%]';
 
 const DapAssetsPath = `${DapAssetsRoot}/${DapAssetsFolder}`;
-const ThirdPartyTag: string = '[%ThirdPartyTag%]';
 const TrackingPixel: string = '[%TrackingPixel%]';
 const ResearchPixel: string = '[%ResearchPixel%]';
 
@@ -25,8 +24,6 @@ const getTag = () => {
 		return fetch(`${DapAssetsPath}/index.html`)
 			.then((res) => res.text())
 			.then(replaceAssetLinks);
-	} else if (ThirdPartyTag) {
-		return fetch(ThirdPartyTag).then((res) => res.text());
 	}
 	return Promise.reject('No tag found');
 };

--- a/src/templates/ssr/fabric-custom/test.json
+++ b/src/templates/ssr/fabric-custom/test.json
@@ -1,6 +1,5 @@
 {
 	"DapAssetsFolder": "GooglePixel2",
-	"ThirdPartyTag": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCrtKGjoAEQARgBMgjYagW3ARF6Fw",
 	"TrackingPixel": "",
 	"ResearchPixel": "",
 	"ViewabilityTracker": "<img src=\"\">",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR removes the ThirdPartyTag from being sumoned from the fabric templates

Originally, this functionality allows us to pull third-party tags, but we currently don’t use or receive them.
 If we ever need to use a third-party JS tag in the future, it can be added to a fabric custom template instead.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Run loacally to ensure the `Inputs` section of the preview doesnt have the `ThirdPartyTag input.
The fabrci template should function as normal populated by GooglePixel 2 ads.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

| Before | After |
|--------|------|
|<img width="431" alt="Screenshot 2024-12-18 at 14 13 14" src="https://github.com/user-attachments/assets/0fbf6395-7d77-4f84-a80a-a4714817d49d" />| <img width="500" alt="Screenshot 2024-12-18 at 14 18 14" src="https://github.com/user-attachments/assets/0050ba36-3a89-440a-8f67-5d7e4d8cde6a" /> |

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
