### PR TITLE
Add visual regression test for Fabric Expandable template

### DIFF
--- a/playwright/fabric-expandable.test.ts
+++ b/playwright/fabric-expandable.test.ts
@@ -12,23 +12,30 @@ test.describe('Fabric Expandable', () => {
 		});
 
 		for (const width of templatePreviewWidths) {
-			const referenceTemplateLocator = page
+			const referenceTemplateLocator = page.locator(`[name='width-${width}']`);
+			const referenceTemplateHtmlLocator = page
 				.frameLocator(`[name='width-${width}']`)
 				.locator('html');
 			// check that the template is present on the page
 			expect(referenceTemplateLocator).toBeVisible();
 			// scroll to it
 			await referenceTemplateLocator.scrollIntoViewIfNeeded();
+			// expand the template ad
+			referenceTemplateHtmlLocator.locator('.toggle-arrow').click();
+			// wait for template expansion transition
+			await new Promise((r) => setTimeout(r, 1500));
+			// take a reference screenshot of the expanded template
+			await referenceTemplateLocator.screenshot({
+				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-expanded.png`,
+			});
+			// collapse the template ad
+			referenceTemplateHtmlLocator.locator('.toggle-arrow').click();
+			// wait for template collapse transition
+			await new Promise((r) => setTimeout(r, 1500));
 			// take a reference screenshot of the template when not expanded
-			// await referenceTemplateLocator.screenshot({
-			// 	path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
-			// });
-			// // expand the template ad
-			// referenceTemplateLocator.locator('.toggle-arrow').click();
-			// // take a reference screenshot of the expanded template
-			// await referenceTemplateLocator.screenshot({
-			// 	path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-expanded.png`,
-			// });
+			await referenceTemplateLocator.screenshot({
+				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
+			});
 		}
 	});
 
@@ -40,30 +47,32 @@ test.describe('Fabric Expandable', () => {
 		});
 
 		for (const width of templatePreviewWidths) {
-			const testTemplateLocator = page
+			const testTemplateLocator = page.locator(`[name='width-${width}']`);
+			const testTemplateHtmlLocator = page
 				.frameLocator(`[name='width-${width}']`)
 				.locator('html');
 			// check that the template is present on the page
 			expect(testTemplateLocator).toBeVisible();
 			// scroll to it
 			await testTemplateLocator.scrollIntoViewIfNeeded();
-			// compare screenshot to reference
-			// await expect(testTemplateLocator).toHaveScreenshot(
-			// 	`Fabric-expandable-${width.replace('%', '')}.png`,
-			// 	{ maxDiffPixelRatio: 0.006 },
-			// );
-			//take a reference screenshot of the template when not expanded
-			await testTemplateLocator.screenshot({
-				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
-			});
 			// expand the template ad
-			testTemplateLocator.locator('.toggle-arrow').click();
+			testTemplateHtmlLocator.locator('.toggle-arrow').click();
 			// wait for template expansion transition
-			await new Promise((r) => setTimeout(r, 2000));
+			await new Promise((r) => setTimeout(r, 1500));
 			// take a reference screenshot of the expanded template
-			await testTemplateLocator.screenshot({
-				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-expanded.png`,
-			});
+			await expect(testTemplateLocator).toHaveScreenshot(
+				`Fabric-expandable-${width.replace('%', '')}-expanded.png`,
+				{ maxDiffPixelRatio: 0.006 },
+			);
+			// collapse the template ad
+			testTemplateHtmlLocator.locator('.toggle-arrow').click();
+			// wait for template collapse transition
+			await new Promise((r) => setTimeout(r, 1500));
+			//take a reference screenshot of the template when not expanded
+			await expect(testTemplateLocator).toHaveScreenshot(
+				`Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
+				{ maxDiffPixelRatio: 0.006 },
+			);
 		}
 	});
 });

--- a/playwright/fabric-expandable.test.ts
+++ b/playwright/fabric-expandable.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { localBaseUrl, referenceBaseUrl, templatePreviewWidths } from './utils';
+
+const viewport = { width: 1600, height: 1000 };
+
+test.describe('Fabric Expandable', () => {
+	test('Get reference screenshots', async ({ page }) => {
+		await page.setViewportSize(viewport);
+
+		await page.goto(`${referenceBaseUrl}csr/fabric-expandable/`, {
+			waitUntil: 'networkidle',
+		});
+
+		for (const width of templatePreviewWidths) {
+			const referenceTemplateLocator = page
+				.frameLocator(`[name='width-${width}']`)
+				.locator('html');
+			// check that the template is present on the page
+			expect(referenceTemplateLocator).toBeVisible();
+			// scroll to it
+			await referenceTemplateLocator.scrollIntoViewIfNeeded();
+			// take a reference screenshot of the template when not expanded
+			// await referenceTemplateLocator.screenshot({
+			// 	path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
+			// });
+			// // expand the template ad
+			// referenceTemplateLocator.locator('.toggle-arrow').click();
+			// // take a reference screenshot of the expanded template
+			// await referenceTemplateLocator.screenshot({
+			// 	path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-expanded.png`,
+			// });
+		}
+	});
+
+	test('Compare PR templates to reference screenshots', async ({ page }) => {
+		await page.setViewportSize(viewport);
+
+		await page.goto(`${localBaseUrl}csr/fabric-expandable`, {
+			waitUntil: 'networkidle',
+		});
+
+		for (const width of templatePreviewWidths) {
+			const testTemplateLocator = page
+				.frameLocator(`[name='width-${width}']`)
+				.locator('html');
+			// check that the template is present on the page
+			expect(testTemplateLocator).toBeVisible();
+			// scroll to it
+			await testTemplateLocator.scrollIntoViewIfNeeded();
+			// compare screenshot to reference
+			// await expect(testTemplateLocator).toHaveScreenshot(
+			// 	`Fabric-expandable-${width.replace('%', '')}.png`,
+			// 	{ maxDiffPixelRatio: 0.006 },
+			// );
+			//take a reference screenshot of the template when not expanded
+			await testTemplateLocator.screenshot({
+				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-not-expanded.png`,
+			});
+			// expand the template ad
+			testTemplateLocator.locator('.toggle-arrow').click();
+			// wait for template expansion transition
+			await new Promise((r) => setTimeout(r, 2000));
+			// take a reference screenshot of the expanded template
+			await testTemplateLocator.screenshot({
+				path: `./playwright/reference-images/Fabric-expandable-${width.replace('%', '')}-expanded.png`,
+			});
+		}
+	});
+});


### PR DESCRIPTION
## What does this change?
Adds a visual regression test for the Fabric Expandable template. I've added a test for both the expanded and non-expanded views of the template, as that means this test will then cover the functionality of the template as well as the appearance.
