### PR TITLE
Override rollup dependencies to minimum version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,10 @@
 		"vite": "^5.4.12"
 	},
 	"type": "module",
-	"packageManager": "pnpm@8.15.5"
+	"packageManager": "pnpm@8.15.5",
+	"pnpm": {
+		"overrides": {
+			"rollup@<2.79.2": ">=2.79.2"
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  rollup@<2.79.2: '>=2.79.2'
+
 devDependencies:
   '@guardian/eslint-config-typescript':
     specifier: ^9.0.1
@@ -579,7 +582,7 @@ packages:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: '>=2.79.2'
     dependencies:
       rollup: 4.22.5
       slash: 3.0.0
@@ -589,7 +592,7 @@ packages:
     resolution: {integrity: sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
-      rollup: ^2.68.0||^3.0.0||^4.0.0
+      rollup: '>=2.79.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -607,7 +610,7 @@ packages:
     resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^2.78.0||^3.0.0||^4.0.0
+      rollup: '>=2.79.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -625,7 +628,7 @@ packages:
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^2.0.0||^3.0.0||^4.0.0
+      rollup: '>=2.79.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -640,7 +643,7 @@ packages:
     resolution: {integrity: sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      rollup: ^2.14.0
+      rollup: '>=2.79.2'
       tslib: '*'
       typescript: '>=3.7.0'
     peerDependenciesMeta:
@@ -658,7 +661,7 @@ packages:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: '>=2.79.2'
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
@@ -678,7 +681,7 @@ packages:
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: '>=2.79.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -946,7 +949,7 @@ packages:
     resolution: {integrity: sha512-Yomg5XvEYfZ9RWAO/5yKhc1QAUXmyI2VOFeMJpAmwhE73EZMsjtuZ+w2Y7gC2c2XHdb+YtymNQrFKqBqyokjfw==}
     dependencies:
       '@types/node': 20.14.5
-      rollup: 0.63.5
+      rollup: 4.22.5
     dev: true
 
   /@types/semver@7.5.8:
@@ -3427,7 +3430,7 @@ packages:
     resolution: {integrity: sha512-7rj9+jB17Pz8LNcPgtMUb16JcgD8lxQMK9HcGfAVhMK3na/WXes3oGIo5QsrQQVqtgAU6q6KnQNXJrYunaUIQQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      rollup: <5
+      rollup: '>=2.79.2'
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.22.5)
       rollup: 4.22.5
@@ -3437,7 +3440,7 @@ packages:
     resolution: {integrity: sha512-hgnIblTRewaBEVQD6N0Q43o+y6q1TmDRhBjaEzQCi50bs8TXqjc+d1zFZyE8tsfgcfNHZQzclh4RxlFUB85H8Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      rollup: '>=2.0.0'
+      rollup: '>=2.79.2'
       svelte: '>=3.5.0'
     dependencies:
       '@rollup/pluginutils': 4.2.1
@@ -3450,21 +3453,13 @@ packages:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
-      rollup: ^2.0.0
+      rollup: '>=2.79.2'
     dependencies:
       '@babel/code-frame': 7.24.7
       jest-worker: 26.6.2
       rollup: 4.22.5
       serialize-javascript: 4.0.0
       terser: 5.31.1
-    dev: true
-
-  /rollup@0.63.5:
-    resolution: {integrity: sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==}
-    hasBin: true
-    dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 20.14.5
     dev: true
 
   /rollup@4.22.5:

--- a/src/lib/rollup.ts
+++ b/src/lib/rollup.ts
@@ -100,7 +100,7 @@ const build = async (
 						.replaceAll('\t', ' ');
 					return false;
 				},
-			}) as Plugin,
+			}),
 		],
 	});
 


### PR DESCRIPTION
The `@types/rollup-plugin-css-only` package lists 1 really old version of rollup as a dependency, which has a high severity vulnerability. The package hasn't been updated in years, so there's no update to resolve the out of date dependency, but we do still need it to handle the types of the css rollup plugin. Overriding the dependency to fix the vulnerability isn't ideal, but I think it's fine in this case, especially since it's a dev dependency.