### PR TITLE
Allow case insensitive HTML tags for `script` regex

### DIFF
--- a/src/lib/svelte.ts
+++ b/src/lib/svelte.ts
@@ -8,7 +8,7 @@ import { gamVar } from '$lib/gam';
 type Props = Record<string, GAMVariable>;
 
 const REGEX = {
-	script: /<script[\s\S]*?>[\s\S]+?<\/script>/g,
+	script: /<script[\s\S]*?>[\s\S]+?<\/script>/gi,
 	props: /export let (.+?): GAMVariable(<[\s\S]+>)?;/g,
 };
 


### PR DESCRIPTION
## What does this change?

Adds `i` to the suffix of the regex for `script` to allow case insensitive matches

## Why

[HTML tags are not case sensitive](https://w3c.github.io/html-reference/documents.html#:~:text=Tag%20names%20for%20HTML%20elements,tag%20names%20are%20case%2Dinsensitive)  

https://github.com/guardian/commercial-templates/security/code-scanning/1