### PR TITLE
Remove hardcoded version of `corepack` from workflows

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -11,10 +11,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         shell: bash
 
@@ -38,10 +34,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         shell: bash
 
@@ -64,10 +56,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - run: corepack enable
         shell: bash

--- a/.github/workflows/gam.yml
+++ b/.github/workflows/gam.yml
@@ -21,10 +21,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         shell: bash
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,10 +21,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         shell: bash
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -13,15 +13,9 @@ jobs:
     name: Visual regression
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - run: corepack enable
         shell: bash


### PR DESCRIPTION
## What does this change?

Unsets hardcoded version of `corepack` in the Github workflows. It shouldn't be needed any more