### PR TITLE
Remove hardcoded version of `corepack` from workflows

### DIFF
--- a/.github/workflows/gam.yml
+++ b/.github/workflows/gam.yml
@@ -44,10 +44,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         shell: bash
 
@@ -79,10 +75,6 @@ jobs:
 
       - name: Install pipenv
         run: pip install pipenv
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - run: corepack enable
         shell: bash


### PR DESCRIPTION
## What does this change?

Unsets hardcoded version of corepack in the Github workflows. It shouldn't be needed any more
Missed a couple from https://github.com/guardian/commercial-templates/pull/438