### PR TITLE
Update link for template instructions

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,7 +39,7 @@
 
 Learn how to create your first template:<a
 	href={`https://github.com/guardian/commercial-templates/blob/${branch}/docs/svelte-template-authoring.md`}
-	>src/templates/README.md</a
+	>docs/svelte-template-authoring.md</a
 >
 
 <hr />


### PR DESCRIPTION
## What does this change?

Updates the link for instructions on creating templates:

|Before | After |
| ----- | ------ |
| <img width="523" alt="image" src="https://github.com/user-attachments/assets/3aa77fa9-a728-48fc-b6e0-04363b69a5d2" /> | <img width="656" alt="image" src="https://github.com/user-attachments/assets/027a3976-7dd1-405a-965f-62e927026f04" /> |

