### PR TITLE
Update fabric custom asset url

### DIFF
--- a/src/lib/fabric-custom-shared.ts
+++ b/src/lib/fabric-custom-shared.ts
@@ -1,5 +1,5 @@
 const CACHE_BUST = '%%CACHEBUSTER%%';
-const DapAssetsRoot = `https://s3-eu-west-1.amazonaws.com/adops-assets/dap-fabrics`;
+const DapAssetsRoot = `https://adops-assets.global.ssl.fastly.net/adops-assets/dap-fabrics`;
 
 const addTrackingPixel = (url: string) => {
 	const pixel = new Image();

--- a/src/lib/fabric-custom-shared.ts
+++ b/src/lib/fabric-custom-shared.ts
@@ -1,5 +1,5 @@
 const CACHE_BUST = '%%CACHEBUSTER%%';
-const DapAssetsRoot = `https://adops-assets.global.ssl.fastly.net/adops-assets/dap-fabrics`;
+const DapAssetsRoot = `https://adops-assets.global.ssl.fastly.net/dap-fabrics`;
 
 const addTrackingPixel = (url: string) => {
 	const pixel = new Image();


### PR DESCRIPTION
## What does this change?
We're deprecating the old s3 URL by blocking public access, updating to the fastly one so fabric customs continue to work.