### PR TITLE
Simplify spacing in CapiCard component

### DIFF
--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -176,9 +176,11 @@
 
 		a.multiple-card:not(:first-of-type)::before {
 			content: '';
+			/** Absolutely positioned relative to the cards-container div */
 			position: absolute;
-			top: 78px;
-			bottom: 102px;
+			/** Top and bottom offset due to margin */
+			top: 12px;
+			bottom: 12px;
 			margin-left: -10px;
 			width: 1px;
 			background: var(--neutral-86);
@@ -193,19 +195,9 @@
 		}
 	}
 
-	@media (min-width: 980px) {
-		a.multiple-card:not(:first-of-type)::before {
-			top: 131px;
-		}
-	}
-
 	@media (min-width: 1140px) {
 		a.single-card .text p {
 			display: block;
-		}
-
-		a.multiple-card:not(:first-of-type)::before {
-			top: 12px;
 		}
 	}
 </style>

--- a/src/templates/csr/capi-multiple-paidfor/index.svelte
+++ b/src/templates/csr/capi-multiple-paidfor/index.svelte
@@ -118,6 +118,8 @@
 		display: flex;
 		flex-direction: column;
 		background-color: var(--neutral-93);
+		/** Needed to absolutely position the horizontal rule between each CapiCard */
+		position: relative;
 	}
 
 	.sponsor-container {


### PR DESCRIPTION
## What does this change?

For the horizontal dividers between CapiCards, use absolute positioning relative to the cards container rather than relative to the entire template

## Why

It makes the code easier to read and understand at first glance
When reading `top: 131px;` it isn't obvious why that value might be used so we instead use `12px` and have a comment in the CSS explaining why

