### PR TITLE
Add video init and progress messages to fabric video (xl)

### DIFF
--- a/src/lib/messenger.ts
+++ b/src/lib/messenger.ts
@@ -49,15 +49,22 @@ type StringMessage = StandardMessage<
 	| 'get-page-url'
 	| 'passback-refresh'
 	| 'viewport'
-	| 'scroll',
+	| 'scroll'
+	| 'init-video',
 	string
+>;
+
+type VideoProgressMessage = StandardMessage<
+	'video-progress',
+	{ progress: number }
 >;
 
 type Message =
 	| ResizeMessage
 	| StringMessage
 	| BackgroundMessage
-	| FabricBackgroundMessage;
+	| FabricBackgroundMessage
+	| VideoProgressMessage;
 
 type MessengerResponse = {
 	id: string;

--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -61,7 +61,20 @@
 			if (video) {
 				if (!VideoURL || !VideoURLMobile) return;
 
+				post({
+					type: 'init-video',
+					value: '',
+				});
+
 				video.load();
+
+				video.ontimeupdate = function () {
+					const percent = Math.round(
+						100 * (video.currentTime / video.duration),
+					);
+					post({ type: 'video-progress', value: { progress: percent } });
+				};
+
 				void video.play();
 
 				const observer = new IntersectionObserver(


### PR DESCRIPTION
## What does this change?
These messages will allow us to track the progress of fabric video and fabric video xl creatives.

The commercial bundle will listen for these messages and use them to setup progress reporting and update the progress, similar to video interscrollers at the moment.