### PR TITLE
Make deploy github action exit with error if there's an error

### DIFF
--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -71,6 +71,7 @@ def upload_template(
             native_style_service.updateNativeStyles([style])
         except Exception as e:
             cprint("[!] Error updating native style: %s" % e, "red")
+            exit(1)
             return
 
         cprint('[✔️] Native style "%s" was updated.' %
@@ -86,7 +87,7 @@ def upload_template(
 def main(native_style_service: common.GoogleSoapService):
     for root, dirs, files in os.walk(template_dir):
         for dir in dirs:
-               upload_template(native_style_service, root, dir)
+            upload_template(native_style_service, root, dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add `exit(1)` to deply script if there's an template update error.

The template upload error is captured and logged but the script doesn't exit with a non-zero exit code so github actions thinks it's all fine and continues.