### PR TITLE
Make sure template variables line up with GAM for fabric-video(-xl)

### DIFF
--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -12,7 +12,7 @@
 	export let TrackingPixel: string;
 	export let ResearchPixel: string;
 	export let ViewabilityPixel: string;
-	export let BackgroundScrollType: 'parallax' | 'none' | 'fixed';
+	export let BackgroundScrollType: 'parallax' | 'none' | 'fixed' = 'none';
 	export let BackgroundColour: string;
 	export let BackgroundImage: string;
 	export let BackgroundImagePosition: string;

--- a/src/templates/csr/fabric-video-xl/index.svelte
+++ b/src/templates/csr/fabric-video-xl/index.svelte
@@ -2,16 +2,14 @@
 	import type { GAMVariable } from '$lib/gam';
 	import Fabric from '$templates/components/Fabric.svelte';
 
-	export let Trackingpixel: GAMVariable;
-	export let Researchpixel: GAMVariable;
-	export let Viewabilitypixel: GAMVariable;
+	export let TrackingPixel: GAMVariable;
+	export let ResearchPixel: GAMVariable;
+	export let ViewabilityPixel: GAMVariable;
 
-	export let BackgroundScrollType: GAMVariable<'parallax' | 'none' | 'fixed'>;
 	export let BackgroundColour: GAMVariable;
-
 	export let BackgroundImage: GAMVariable;
-	export let BackgroundImagePosition: GAMVariable;
-	export let BackgroundImageRepeat: GAMVariable;
+	export let BackgroundPosition: GAMVariable;
+	export let BackgroundRepeat: GAMVariable;
 	export let Layer1BackgroundImage: GAMVariable;
 	export let Layer1BackgroundPosition: GAMVariable;
 	export let Layer2BackgroundImage: GAMVariable;
@@ -20,8 +18,8 @@
 	export let Layer3BackgroundPosition: GAMVariable;
 
 	export let MobileBackgroundImage: GAMVariable;
-	export let MobileBackgroundImagePosition: GAMVariable;
-	export let MobileBackgroundImageRepeat: GAMVariable;
+	export let MobileBackgroundPosition: GAMVariable;
+	export let MobileBackgroundRepeat: GAMVariable;
 	export let MobileLayer1BackgroundImage: GAMVariable;
 	export let MobileLayer1BackgroundPosition: GAMVariable;
 	export let MobileLayer2BackgroundImage: GAMVariable;
@@ -37,17 +35,16 @@
 </script>
 
 <Fabric
-	TrackingPixel={Trackingpixel}
-	ResearchPixel={Researchpixel}
-	ViewabilityPixel={Viewabilitypixel}
-	{BackgroundScrollType}
+	{TrackingPixel}
+	{ResearchPixel}
+	{ViewabilityPixel}
 	{BackgroundColour}
 	{BackgroundImage}
-	{BackgroundImagePosition}
-	{BackgroundImageRepeat}
+	BackgroundImagePosition={BackgroundPosition}
+	BackgroundImageRepeat={BackgroundRepeat}
 	{MobileBackgroundImage}
-	{MobileBackgroundImagePosition}
-	{MobileBackgroundImageRepeat}
+	MobileBackgroundImagePosition={MobileBackgroundPosition}
+	MobileBackgroundImageRepeat={MobileBackgroundRepeat}
 	{Layer1BackgroundImage}
 	{Layer1BackgroundPosition}
 	{Layer2BackgroundImage}

--- a/src/templates/csr/fabric-video/index.svelte
+++ b/src/templates/csr/fabric-video/index.svelte
@@ -6,12 +6,10 @@
 	export let Researchpixel: GAMVariable;
 	export let Viewabilitypixel: GAMVariable;
 
-	export let BackgroundScrollType: GAMVariable<'parallax' | 'none' | 'fixed'>;
 	export let BackgroundColour: GAMVariable;
-
 	export let BackgroundImage: GAMVariable;
-	export let BackgroundImagePosition: GAMVariable;
-	export let BackgroundImageRepeat: GAMVariable;
+	export let BackgroundPosition: GAMVariable;
+	export let BackgroundRepeat: GAMVariable;
 	export let Layer1BackgroundImage: GAMVariable;
 	export let Layer1BackgroundPosition: GAMVariable;
 	export let Layer2BackgroundImage: GAMVariable;
@@ -20,8 +18,8 @@
 	export let Layer3BackgroundPosition: GAMVariable;
 
 	export let MobileBackgroundImage: GAMVariable;
-	export let MobileBackgroundImagePosition: GAMVariable;
-	export let MobileBackgroundImageRepeat: GAMVariable;
+	export let MobileBackgroundPosition: GAMVariable;
+	export let MobileBackgroundRepeat: GAMVariable;
 	export let MobileLayer1BackgroundImage: GAMVariable;
 	export let MobileLayer1BackgroundPosition: GAMVariable;
 	export let MobileLayer2BackgroundImage: GAMVariable;
@@ -40,14 +38,13 @@
 	TrackingPixel={Trackingpixel}
 	ResearchPixel={Researchpixel}
 	ViewabilityPixel={Viewabilitypixel}
-	{BackgroundScrollType}
 	{BackgroundColour}
 	{BackgroundImage}
-	{BackgroundImagePosition}
-	{BackgroundImageRepeat}
+	BackgroundImagePosition={BackgroundPosition}
+	BackgroundImageRepeat={BackgroundRepeat}
 	{MobileBackgroundImage}
-	{MobileBackgroundImagePosition}
-	{MobileBackgroundImageRepeat}
+	MobileBackgroundImagePosition={MobileBackgroundPosition}
+	MobileBackgroundImageRepeat={MobileBackgroundRepeat}
 	{Layer1BackgroundImage}
 	{Layer1BackgroundPosition}
 	{Layer2BackgroundImage}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The variables are slightly incorrect, this causes a deploy error and the templates to not update.

The error wasn't clear as the action didn't fail! Fixed in another PR #450 

```
[i] Updating native style "Web - Fabric Video".
[!] Error updating native style: [NativeStyleError.UNRECOGNIZED_PLACEHOLDER @ [0].htmlSnippet; trigger:'BackgroundImagePosition, BackgroundImageRepeat, BackgroundScrollType, MobileBackgroundImagePosition, MobileBackgroundImageRepeat']
...
[✔️] Native style "Web - Fabric - video -XL" with ID "705671" was found for template "fabric-video-xl".
[i] Updating native style "Web - Fabric - video -XL".
[!] Error updating native style: [NativeStyleError.UNRECOGNIZED_PLACEHOLDER @ [0].htmlSnippet; trigger:'BackgroundImagePosition, BackgroundImageRepeat, BackgroundScrollType, MobileBackgroundImagePosition, MobileBackgroundImageRepeat, Researchpixel, Trackingpixel, Viewabilitypixel']
```