### PR TITLE
Fix image aspect ratio to 5/4 for CapiCard

### DIFF
--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -83,12 +83,14 @@
 	}
 
 	a.multiple-card {
+		flex-basis: 100%;
 		margin: 12px 10px 0px 10px;
 		display: block;
 		padding: 0 0 8px 0;
 		width: auto;
 		background-color: var(--neutral-97);
 		border-top: 1px solid var(--labs-400);
+		overflow: hidden;
 	}
 
 	a.multiple-card:hover {
@@ -102,13 +104,26 @@
 	a.multiple-card .media {
 		background-color: gray;
 		margin: 0;
+		width: 100%;
+
+		// Fix 5 : 4 aspect ratio
+		picture {
+			padding-top: calc(4 / 5 * 100%);
+			position: relative;
+			& > * {
+				position: absolute;
+				top: 0;
+				left: 0;
+				height: 100%;
+				width: auto;
+			}
+		}
 	}
 
 	picture,
 	img {
 		display: block;
 		width: 100%;
-		min-height: 80px;
 	}
 
 	a.single-card .text {


### PR DESCRIPTION
## What does this change?

Forces images in `CapiCard` to adopt 5:4 aspect ratio for **multiple-card variation only** since this is now the default trail image size

Takes inspiration from [DCR's `CardPicture` component](https://github.com/guardian/dotcom-rendering/blob/0fa6c405eb4ba9f4c5ba9b7a839ea41f61af2a4d/dotcom-rendering/src/components/CardPicture.tsx#L161-L171)

## Why

When cards appear next to each other with different aspect ratios it looks a bit clunky. Better to align and decide on one aspect ratio to apply to all

## Images

| Before | After |
| ------ | ----- |
| ![before_m][] | ![after_m][] |
| ![before_t][] | ![after_t][] |
| ![before_d][] | ![after_d][] |
| ![before_w][] | ![after_w][] |

[before_m]: https://github.com/user-attachments/assets/a9311874-5ef5-4acd-92d8-e773fa9fad9b
[after_m]: https://github.com/user-attachments/assets/4d1485d1-fea4-40f1-9176-e434fa1e01d4
[before_t]: https://github.com/user-attachments/assets/b110e5da-5654-43b0-a893-af50c56f4384
[after_t]: https://github.com/user-attachments/assets/00bb0b18-4c7d-43c0-a9fa-9a1a15a46a19
[before_d]: https://github.com/user-attachments/assets/163ed0ed-bb48-4740-b4ad-39f5a063370d
[after_d]: https://github.com/user-attachments/assets/4503e737-697b-4e36-bc15-12b69aec4c57
[before_w]: https://github.com/user-attachments/assets/5089c5f3-94ac-4e82-8135-ab0874fb4149
[after_w]: https://github.com/user-attachments/assets/34fde6b5-75d9-486c-bf40-a8d02b7ef153
