### PR TITLE
Allow more height for iframes in preview

### DIFF
--- a/src/lib/Previews.svelte
+++ b/src/lib/Previews.svelte
@@ -88,8 +88,8 @@
 				frameborder="0"
 				{width}
 				srcdoc={transformed}
-				height="650"
 				name={`width-${width}`}
+				height="700"
 			/>
 		</div>
 	{/each}


### PR DESCRIPTION
## What does this change?

Increases `iframe` height in preview page from `650` to `700`

## Images

| Before | After |
| ----- | ----- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/42ece8ca-0b43-4a82-a373-2ee6ec2f6862
[after]: https://github.com/user-attachments/assets/1279c8c9-e263-4e6c-a712-9bbd28ded14d


