### PR TITLE
Improve image alignment for 5/4 CAPI multiple card

### DIFF
--- a/src/templates/components/CapiCard.svelte
+++ b/src/templates/components/CapiCard.svelte
@@ -112,8 +112,9 @@
 			position: relative;
 			& > * {
 				position: absolute;
-				top: 0;
-				left: 0;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
 				height: 100%;
 				width: auto;
 			}


### PR DESCRIPTION
## What does this change?

Ensures the 5:4 image is centered for 5:3 trail images

## Why

So we don't miss seeing the likely point of focus for the image

## Images

| Before | After | 
| ----- | ----- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/41ae03af-cd6e-4875-8bf3-770ab8cde6a0
[after]: https://github.com/user-attachments/assets/15022514-a449-40b7-9b32-23844310e1b1
[before2]: https://github.com/user-attachments/assets/b323b983-f819-42fd-aa6d-35274a388bf6
[after2]: https://github.com/user-attachments/assets/6be1dfaa-0fa2-4dc9-b4b2-466d7496a3c7
