### PR TITLE
Fix CSS for Fabric Video XL native template

### DIFF
--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -155,7 +155,7 @@
 			autoplay
 			playsinline
 			class="video video--{VideoAlignment}"
-			class:isMobile
+			class:is-mobile={isMobile}
 			on:ended={() => (played = true)}
 			src={videoSrc}
 			poster={posterImage}
@@ -176,9 +176,6 @@
 		background-color: var(--background-color);
 		margin: 0;
 	}
-	.isMobile {
-		width: 740px;
-	}
 
 	.video,
 	.poster,
@@ -194,6 +191,14 @@
 	.video {
 		width: 1920px;
 		height: 250px;
+
+		&.is-mobile {
+			width: 740px;
+		}
+
+		.is-xl & {
+			height: 500px;
+		}
 	}
 
 	.video--left {


### PR DESCRIPTION
## What does this change?

Fixes an issue with the fabric video XL native template where the explicit setting of the video to 500px high was missed for the XL variation

## Why

The XL template was behaving in the same way as the standard video template and wasn't expanding to fill the space

## Images

| Before | After |
| ----- | ----- |
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://github.com/user-attachments/assets/e0de1c3c-a766-43b0-944a-61da5cf7aad9
[after]: https://github.com/user-attachments/assets/d2f5ad81-9ea3-4298-8177-26bca5f8c639
[before2]: https://github.com/user-attachments/assets/ce3888ea-40ff-410b-9ed5-9167c884fb12
[after2]: https://github.com/user-attachments/assets/d60469e1-2af7-4010-9c36-2720c1e1bd4b


