### PR TITLE
Include `ad.json` file where it was missing for some templates

### DIFF
--- a/src/templates/csr/capi-single-paidfor/ad.json
+++ b/src/templates/csr/capi-single-paidfor/ad.json
@@ -1,0 +1,3 @@
+{
+	"nativeStyleId": "75859"
+}

--- a/src/templates/csr/events-multiple/ad.json
+++ b/src/templates/csr/events-multiple/ad.json
@@ -1,0 +1,3 @@
+{
+	"nativeStyleId": "790575"
+}

--- a/src/templates/ssr/manual-single/ad.json
+++ b/src/templates/ssr/manual-single/ad.json
@@ -1,0 +1,3 @@
+{
+	"nativeStyleId": "71688"
+}


### PR DESCRIPTION
## What does this change?

Adds `ad.json` file for the following templates:
- [capi-single-paidfor](https://github.com/guardian/commercial-templates/tree/main/src/templates/csr/capi-single-paidfor): native style ID [75859](https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=75859)
- [events-multiple](https://github.com/guardian/commercial-templates/tree/main/src/templates/csr/events-multiple): native style ID [790575](https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=790575)
- [manual-single](https://github.com/guardian/commercial-templates/tree/main/src/templates/ssr/manual-single): native style ID [71688](https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=71688)

## Why

These templates had not been deploying to GAM on merge to main

![image](https://github.com/user-attachments/assets/3d2386fd-d743-4901-8800-b881771f2558)

I assume this is a mistake