### PR TITLE
Revert "Include `ad.json` file where it was missing for some templates"

### DIFF
--- a/src/templates/csr/capi-single-paidfor/ad.json
+++ b/src/templates/csr/capi-single-paidfor/ad.json
@@ -1,3 +1,0 @@
-{
-	"nativeStyleId": "75859"
-}

--- a/src/templates/csr/events-multiple/ad.json
+++ b/src/templates/csr/events-multiple/ad.json
@@ -1,3 +1,0 @@
-{
-	"nativeStyleId": "790575"
-}

--- a/src/templates/ssr/manual-single/ad.json
+++ b/src/templates/ssr/manual-single/ad.json
@@ -1,3 +1,0 @@
-{
-	"nativeStyleId": "71688"
-}


### PR DESCRIPTION
## What

Reverts guardian/commercial-templates#457

## Why

The [deploy failed](https://github.com/guardian/commercial-templates/actions/runs/15558341775) so we either need to fix the deploys or label these as non deployable instead