### PR TITLE
Update Github workflow permissions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
   pull_request:
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   test:


### PR DESCRIPTION
## What does this change?

Update permissions for two Github workflows in this repo:

### PR

This workflow didn't specify permissions available to it so `contents: read` has been included for this one

### visual-regression

This workflow had quite relaxed permissions available to it (`write-all`) so these have been tightened to reduce the scope 