### PR TITLE
Fix preview for CAPI multiple hosted template

### DIFF
--- a/src/templates/csr/capi-multiple-hosted/test.json
+++ b/src/templates/csr/capi-multiple-hosted/test.json
@@ -1,5 +1,5 @@
 {
-	"SeriesURL": "xero-level-up",
+	"SeriesURL": "advertiser-content/get-to-know-me",
 	"BrandLogo": "",
 	"BrandColour": "#222B5E",
 	"TrackingID": "",


### PR DESCRIPTION
## What does this change?

Updates the series URL for the CAPI multiple hosted template preview in the commercial templates tool

## Why

The previous series URL used for previewing this template was taken down and unavailable

## Screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/f37ae1d2-fa9b-4a88-a49d-ffc3d003d9f8
[after]: https://github.com/user-attachments/assets/053e2493-ced3-4bf8-b2d0-5dec7de2ddec
