### PR TITLE
Update dependabot schedule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
       time: '09:00'
     groups:
       rollup:
@@ -58,4 +59,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'


### PR DESCRIPTION
## What does this change?

Updates the dependabot schedule to raise PRs once a week (on Mondays) instead of daily

## Why?

Reducing alert fatigue and PR merging frequency (we don't need to merge every single patch change to a package). 
We don't need this repo to be updated daily so let's reduce the frequency of these PRs.
