### PR TITLE
Fabric Video: bug with videos at 1300px when alignment is set to left or right

### DIFF
--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -39,7 +39,9 @@
 	export let VideoAlignment: GAMVariable | undefined = undefined;
 	export let showVideo: boolean = false;
 	export let isXL: boolean = false;
+	export let FullWidthTopSlot: 'yes' | 'no';
 
+	
 	const isMobile = window.matchMedia('(max-width: 739px)').matches;
 	const isTablet = window.matchMedia(
 		'(min-width: 740px) and (max-width: 979px)',
@@ -50,6 +52,7 @@
 
 	const posterImage = isMobile ? MobileVideoBackupImage : VideoBackupImage;
 	const videoSrc = isMobile ? VideoURLMobile : VideoURL;
+
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- https://github.com/sveltejs/eslint-plugin-svelte/issues/476
 	if (showVideo) {
@@ -155,6 +158,7 @@
 			autoplay
 			playsinline
 			class="video video--{VideoAlignment}"
+			class:is-top-slot-video={FullWidthTopSlot === 'yes'}
 			class:is-mobile={isMobile}
 			on:ended={() => (played = true)}
 			src={videoSrc}
@@ -189,7 +193,7 @@
 	}
 
 	.video {
-		width: 1920px;
+		width: 1300px;
 		height: 250px;
 
 		&.is-mobile {
@@ -198,6 +202,10 @@
 
 		.is-xl & {
 			height: 500px;
+		}
+
+		&.is-top-slot-video {
+			width: 1920px;
 		}
 	}
 

--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -124,6 +124,7 @@
 	class="fabric-container"
 	class:is-parallax={BackgroundScrollType === 'parallax'}
 	class:is-xl={isXL}
+	class:is-top-slot-video={FullWidthTopSlot === 'yes'}
 	href={`${CLICK_MACRO}${DEST_URL}`}
 	target="_blank"
 >
@@ -256,6 +257,12 @@
 		}
 		@media (min-width: 1300px) {
 			max-width: 1300px;
+		}
+
+		&.is-top-slot-video {
+			@media (min-width: 1300px) {
+				max-width: 1920px;
+			}
 		}
 	}
 

--- a/src/templates/components/Fabric.svelte
+++ b/src/templates/components/Fabric.svelte
@@ -41,7 +41,6 @@
 	export let isXL: boolean = false;
 	export let FullWidthTopSlot: 'yes' | 'no';
 
-	
 	const isMobile = window.matchMedia('(max-width: 739px)').matches;
 	const isTablet = window.matchMedia(
 		'(min-width: 740px) and (max-width: 979px)',
@@ -52,7 +51,6 @@
 
 	const posterImage = isMobile ? MobileVideoBackupImage : VideoBackupImage;
 	const videoSrc = isMobile ? VideoURLMobile : VideoURL;
-
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- https://github.com/sveltejs/eslint-plugin-svelte/issues/476
 	if (showVideo) {

--- a/src/templates/csr/fabric-expandable/index.svelte
+++ b/src/templates/csr/fabric-expandable/index.svelte
@@ -83,6 +83,7 @@
 		MobileLayer2BackgroundPosition={Slide1Layer2MobileBackgroundPosition}
 		MobileLayer3BackgroundImage={Slide1Layer3MobileBackgroundImage}
 		MobileLayer3BackgroundPosition={Slide1Layer3MobileBackgroundPosition}
+		FullWidthTopSlot={'no'}
 	/>
 
 	<Fabric
@@ -109,6 +110,7 @@
 		MobileLayer2BackgroundPosition={Slide2Layer2MobileBackgroundPosition}
 		MobileLayer3BackgroundImage={Slide2Layer3MobileBackgroundImage}
 		MobileLayer3BackgroundPosition={Slide2Layer3MobileBackgroundPosition}
+		FullWidthTopSlot={'no'}
 	/>
 
 	<div class={expanded ? 'button-container expanded' : 'button-container'}>

--- a/src/templates/csr/fabric-video-xl/index.svelte
+++ b/src/templates/csr/fabric-video-xl/index.svelte
@@ -64,4 +64,5 @@
 	{VideoAlignment}
 	isXL={true}
 	showVideo={true}
+	FullWidthTopSlot={'no'}
 />

--- a/src/templates/csr/fabric-video-xl/test.json
+++ b/src/templates/csr/fabric-video-xl/test.json
@@ -24,6 +24,7 @@
 	"VideoBackupImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCLn8ywtAEQARgBMgilQLMRCw4e5A",
 	"MobileVideoBackupImage": "",
 	"VideoAlignment": "center",
+	"IsFullWidthTopSlot": "no",
 	"Trackingpixel": "",
 	"Researchpixel": "",
 	"Viewabilitypixel": "",

--- a/src/templates/csr/fabric-video/index.svelte
+++ b/src/templates/csr/fabric-video/index.svelte
@@ -32,6 +32,7 @@
 	export let MobileVideoBackupImage: GAMVariable;
 	export let VideoURLMobile: GAMVariable;
 	export let VideoAlignment: GAMVariable;
+	export let IsFullWidthTopSlot: GAMVariable<'yes' | 'no'>;
 </script>
 
 <Fabric
@@ -63,4 +64,5 @@
 	{VideoURLMobile}
 	{VideoAlignment}
 	showVideo={true}
+	FullWidthTopSlot={IsFullWidthTopSlot}
 />

--- a/src/templates/csr/fabric-video/test.json
+++ b/src/templates/csr/fabric-video/test.json
@@ -24,6 +24,7 @@
 	"VideoBackupImage": "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCLn8ywtAEQARgBMgilQLMRCw4e5A",
 	"MobileVideoBackupImage": "",
 	"VideoAlignment": "center",
+	"IsFullWidthTopSlot": "no",
 	"Trackingpixel": "",
 	"Researchpixel": "",
 	"Viewabilitypixel": "",

--- a/src/templates/csr/fabric-xl/index.svelte
+++ b/src/templates/csr/fabric-xl/index.svelte
@@ -54,5 +54,6 @@
 	{MobileLayer2BackgroundPosition}
 	{MobileLayer3BackgroundImage}
 	{MobileLayer3BackgroundPosition}
+	FullWidthTopSlot={'no'}
 	isXL={true}
 />

--- a/src/templates/csr/fabric/index.svelte
+++ b/src/templates/csr/fabric/index.svelte
@@ -54,4 +54,5 @@
 	{MobileLayer2BackgroundPosition}
 	{MobileLayer3BackgroundImage}
 	{MobileLayer3BackgroundPosition}
+	FullWidthTopSlot={'no'}
 />


### PR DESCRIPTION


## What does this change?

Video width is set to 1920px, this PR makes 1300px the default value, and adds a new option to the template in GAM, adding css class allowing 1920px videos in the top above nav slot if needed.

At the moment a side effect of the width being set to 1920px is that the more commonly used 1300px video, that has it's alignment set to anything other than centre does not render as expected.


isFullWidthTopSlot multi options, 'yes' or 'no', defaults to 'no' as most videos will be 1300px.


![new-option](https://github.com/user-attachments/assets/a69dceb1-4c0b-4a2e-850d-05f1555d8f74)



## How to test

I have created a DAP test format in GAM and setup some adtests.


https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=279700&tab=ad_settings



1300px video aligned right - current fabric video template
https://www.theguardian.com/uk/culture?adtest=video_bug


Expected - Template with the fix
https://www.theguardian.com/uk/culture?adtest=no_1300



Full width 1920 - with fix working as expected
 
https://www.theguardian.com/uk/culture?adtest=max_width_bug

https://admanager.google.com/59666047#delivery/line_item/detail/line_item_id=7082695123&order_id=2462673338&li_tab=settings&sort_by=Name&sort_asc=true




## Have we considered potential risks?

This change does touch all fabrics as all formats share the fabric component. But it shouldn't only affect the fabric video.

## Images

1300px aligned right without fix

<img width="3510" height="2696" alt="video-right-bug" src="https://github.com/user-attachments/assets/7f8fed19-16cc-4086-893e-2007290ce10e" />


1300px aligned right with isFullWidthTopSlot set to 'no'

<img width="1737" height="1048" alt="1300px-expected" src="https://github.com/user-attachments/assets/e12203e2-e742-42e7-803a-cff73a80dc04" />


1920px video in top above nav with isFullWidthTopSlot set to 'yes'

<img width="1748" height="1067" alt="1920px" src="https://github.com/user-attachments/assets/d0a1a919-f267-46d6-9030-4c3c5ce1a1e6" />


