### PR TITLE
CAPI Hosted Tweaks

### DIFF
--- a/src/lib/components/CapiHostedCard.svelte
+++ b/src/lib/components/CapiHostedCard.svelte
@@ -80,6 +80,8 @@
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
+		// Prevent images expanding the height of the ad
+		max-height: 360px;
 	}
 
 	h2 {
@@ -123,6 +125,7 @@
 
 	@media (min-width: 740px) {
 		.media {
+			display: flex;
 			max-height: 60%;
 
 			.singleCard & {

--- a/src/routes/templates/capi-multiple-hosted/+page.svelte
+++ b/src/routes/templates/capi-multiple-hosted/+page.svelte
@@ -174,7 +174,11 @@
 	@media (min-width: 1300px) {
 		aside {
 			grid-template-columns: 219px 1fr;
-			margin-right: 21px;
+			/*
+			 * Equivalent of 60px grid column + 20px gap
+			 * @todo - replace this with the Guardian grid
+			 */
+			margin-right: 80px;
 		}
 	}
 </style>


### PR DESCRIPTION
## What does this change?

- Add max height of 360px for CAPI hosted images
  This should reduce the overall size of the adverts to avoid them appearing too large on the page 
- Add extra padding to the right hand side of the advert for wide screens
  This makes the advert appear smaller as any cards inside cannot occupy the space on the right hand side which is usually kept free on fronts and articles

## Why

We've had reports of the CAPI Multiple Hosted template not looking right for an upcoming campaign

## Screenshots

_Both `wide` size (1300px):_
| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |


[before]:https://github.com/user-attachments/assets/d481a982-4bfe-4e26-b948-3e51ba150f5e
[after]:https://github.com/user-attachments/assets/9cd2cad5-12a4-4f02-82b7-bcecbba658ab
