### PR TITLE
Revert "Replace missing brackets in interscroller template"

### DIFF
--- a/src/routes/templates/capi-multiple-hosted/variables.gam.ts
+++ b/src/routes/templates/capi-multiple-hosted/variables.gam.ts
@@ -15,5 +15,5 @@ export const gamVariables = {
 	Article4Headline: '',
 	Article4Image: '',
 	Article4URL: '',
-	numberOfElements: '1',
+	numberOfElements: '4',
 };


### PR DESCRIPTION
Reverts guardian/commercial-templates#611

This PR was a mistake!