### PR TITLE
Image template with tracking for adops

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"build:template:mobile-revealer": "BUILD_TEMPLATE=mobile-revealer REPLACE_GAM_VARS=true vite build",
 		"build:template:public-good": "BUILD_TEMPLATE=public-good REPLACE_GAM_VARS=true vite build",
 		"build:template:public-good-test": "BUILD_TEMPLATE=public-good-test REPLACE_GAM_VARS=true vite build",
+		"build:template:image-native": "BUILD_TEMPLATE=image-native REPLACE_GAM_VARS=true vite build",
 		"build:templates": "pnpm run /^build:template:.*/",
 		"publish": "pnpm gh-pages --dist build --dotfiles",
 		"deploy": "pnpm build && pnpm publish",

--- a/playwright/image-native.test.ts
+++ b/playwright/image-native.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { localBaseUrl, referenceBaseUrl, templatePreviewWidths } from './utils';
+
+const viewport = { width: 1600, height: 1000 };
+
+test.describe('image native', () => {
+	test('Get reference screenshots', async ({ page }) => {
+		await page.setViewportSize(viewport);
+
+		await page.goto(`${referenceBaseUrl}/image-native/`, {
+			waitUntil: 'networkidle',
+		});
+
+		for (const width of templatePreviewWidths) {
+			const referenceTemplateLocator = page
+				.frameLocator(`[name='width-${width}']`)
+				.locator('html');
+			// check that the template is present on the page
+			expect(referenceTemplateLocator).toBeVisible();
+			// scroll to it
+			await referenceTemplateLocator.scrollIntoViewIfNeeded();
+			// take a reference screenshot
+			await referenceTemplateLocator.screenshot({
+				path: `./playwright/reference-images/Image-native-${width.replace('%', '')}.png`,
+			});
+		}
+	});
+
+	test('Compare PR templates to reference screenshots', async ({ page }) => {
+		await page.setViewportSize(viewport);
+
+		await page.goto(`${localBaseUrl}/image-native`, {
+			waitUntil: 'networkidle',
+		});
+
+		for (const width of templatePreviewWidths) {
+			const testTemplateLocator = page
+				.frameLocator(`[name='width-${width}']`)
+				.locator('html');
+			// check that the template is present on the page
+			expect(testTemplateLocator).toBeVisible();
+			// scroll to it
+			await testTemplateLocator.scrollIntoViewIfNeeded();
+			// compare screenshot to reference
+			await expect(testTemplateLocator).toHaveScreenshot(
+				`Image-native-${width.replace('%', '')}.png`,
+				{ maxDiffPixelRatio: 0.006 },
+			);
+		}
+	});
+});

--- a/src/routes/templates/image-native/+page.svelte
+++ b/src/routes/templates/image-native/+page.svelte
@@ -8,8 +8,8 @@
 	let {
 		BackgroundImageX1,
 		BackgroundImageX2,
-		adWidth,
-		adHeight,
+		AdWidth,
+		AdHeight,
 		TrackingPixel,
 		ResearchPixel,
 		ViewabilityTracker,
@@ -18,8 +18,8 @@
 
 <div
 	class="creative creative--image"
-	style:--width={`${adWidth}px`}
-	style:--height={`${adHeight}px`}
+	style:--width={`${AdWidth}px`}
+	style:--height={`${AdHeight}px`}
 >
 	<a
 		class="creative__cta"
@@ -29,7 +29,7 @@
 		<picture>
 			<source srcset={`${BackgroundImageX1}, ${BackgroundImageX2} 2x`} />
 			<!-- svelte-ignore a11y-missing-attribute -->
-			<img src={BackgroundImageX1} width={adWidth} height={adHeight} />
+			<img src={BackgroundImageX1} width={AdWidth} height={AdHeight} />
 		</picture>
 	</a>
 	<!-- svelte-ignore a11y-missing-attribute -->

--- a/src/routes/templates/image-native/+page.svelte
+++ b/src/routes/templates/image-native/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { building } from '$app/environment';
+	import type { PageData } from './$types';
+	import { CACHE_BUST } from '$lib/gam';
+
+	export let data: PageData;
+
+	let {
+		BackgroundImageX1,
+		BackgroundImageX2,
+		adWidth,
+		adHeight,
+		TrackingPixel,
+		ResearchPixel,
+		ViewabilityTracker,
+	} = data;
+</script>
+
+<div
+	class="creative creative--image"
+	style:--width={adWidth}
+	style:--height={adHeight}
+>
+	<a
+		class="creative__cta"
+		href="%%CLICK_URL_UNESC%%%%DEST_URL_ESC%%"
+		target="_blank"
+	>
+		<picture>
+			<source srcset={`${BackgroundImageX1}, ${BackgroundImageX2} 2x`} />
+			<!-- svelte-ignore a11y-missing-attribute -->
+			<img src={BackgroundImageX1} width={adWidth} height={adHeight} />
+		</picture>
+	</a>
+	<!-- svelte-ignore a11y-missing-attribute -->
+	<img
+		src="{TrackingPixel}{CACHE_BUST}"
+		class="creative__pixel creative__pixel--displayNone"
+		aria-hidden="true"
+	/>
+	<!-- svelte-ignore a11y-missing-attribute -->
+	<img
+		src="{ResearchPixel}{CACHE_BUST}"
+		class="creative__pixel creative__pixel--displayNone"
+		aria-hidden="true"
+	/>
+	<!-- svelte-ignore a11y-missing-attribute -->
+	<img
+		src={ViewabilityTracker}
+		class="creative__pixel creative__pixel--displayNone"
+		aria-hidden="true"
+	/>
+
+	<!-- This will only add the GAM tag when pre-rendering as a raw string, these JS tags have been known to cause issues when injected into svelte's compiled JS by GAM -->
+	{#if building}
+		[%thirdPartyJSTracking%]
+	{/if}
+</div>
+
+<style lang="scss">
+	.creative {
+		&--image {
+			//unitless variable from GAM using
+			//calc to force to px
+			width: calc(var(--width) * 1px);
+			height: calc(var(--height) * 1px);
+		}
+
+		&__pixel--displayNone {
+			display: none;
+		}
+	}
+</style>

--- a/src/routes/templates/image-native/+page.svelte
+++ b/src/routes/templates/image-native/+page.svelte
@@ -18,8 +18,8 @@
 
 <div
 	class="creative creative--image"
-	style:--width={adWidth}
-	style:--height={adHeight}
+	style:--width={`${adWidth}px`}
+	style:--height={`${adHeight}px`}
 >
 	<a
 		class="creative__cta"
@@ -60,10 +60,9 @@
 <style lang="scss">
 	.creative {
 		&--image {
-			//unitless variable from GAM using
-			//calc to force to px
-			width: calc(var(--width) * 1px);
-			height: calc(var(--height) * 1px);
+			width: var(--width);
+			height: var(--height);
+			margin-inline: auto;
 		}
 
 		&__pixel--displayNone {

--- a/src/routes/templates/image-native/+page.ts
+++ b/src/routes/templates/image-native/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from './$types';
+import { gamVariables } from './variables.gam';
+
+export const prerender = true;
+
+export const load = (() => {
+	return gamVariables;
+}) satisfies PageLoad;

--- a/src/routes/templates/image-native/ad.json
+++ b/src/routes/templates/image-native/ad.json
@@ -1,0 +1,6 @@
+{
+	"nativeStyleId": "986360",
+	"creativeTemplateId": "12534062",
+	"testNativeStyleId": "962313",
+	"testCreativeId": "12532595"
+}

--- a/src/routes/templates/image-native/ad.json
+++ b/src/routes/templates/image-native/ad.json
@@ -2,5 +2,5 @@
 	"nativeStyleId": "986360",
 	"creativeTemplateId": "12534062",
 	"testNativeStyleId": "962313",
-	"testCreativeId": "12532595"
+	"testCreativeId": "138555949044"
 }

--- a/src/routes/templates/image-native/variables.gam.ts
+++ b/src/routes/templates/image-native/variables.gam.ts
@@ -1,0 +1,11 @@
+export const gamVariables = {
+	BackgroundImageX1:
+		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux1.jpg',
+	BackgroundImageX2:
+		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux2.jpg',
+	adWidth: 300,
+	adHeight: 250,
+	TrackingPixel: '',
+	ResearchPixel: '',
+	ViewabilityTracker: '',
+};

--- a/src/routes/templates/image-native/variables.gam.ts
+++ b/src/routes/templates/image-native/variables.gam.ts
@@ -3,8 +3,8 @@ export const gamVariables = {
 		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux1.jpg',
 	BackgroundImageX2:
 		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux2.jpg',
-	adWidth: 300,
-	adHeight: 250,
+	adWidth: '970',
+	adHeight: '250',
 	TrackingPixel: '',
 	ResearchPixel: '',
 	ViewabilityTracker: '',

--- a/src/routes/templates/image-native/variables.gam.ts
+++ b/src/routes/templates/image-native/variables.gam.ts
@@ -3,8 +3,8 @@ export const gamVariables = {
 		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux1.jpg',
 	BackgroundImageX2:
 		'https://adops-assets.global.ssl.fastly.net/dap-fabrics/DAP_image_assets_for_testing/mpux2.jpg',
-	adWidth: '970',
-	adHeight: '250',
+	AdWidth: '300',
+	AdHeight: '250',
 	TrackingPixel: '',
 	ResearchPixel: '',
 	ViewabilityTracker: '',


### PR DESCRIPTION
# Simple Image template

There has been a few situations with DAP and adops where adops needs to use certain tracking tags that are not available on the standard GAM image template, so they use another Creative template within GAM. But that template doesn't accept x2 images.

This pull request introduces a simple native image template that accepts width and height so it can be any size, can accept x1 and x2 images and has extra tracking.

The choice to create as a native template over just updating the Creative template on GAM is that this can be used by both direct and programmatic teams and keeps the code within this repo.

## Testing 
Adtest is up here. Should be able to see a x1 image or x2
https://www.theguardian.com/books?adtest=native_image

https://admanager.google.com/59666047#delivery/line_item/detail/line_item_id=7280754900&order_id=2462673338&li_tab=settings&sort_by=StartDateTime&sort_asc=false


Test native style is here

id: 962313

https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=962313&tab=ad_settings


