### PR TITLE
Bump `@sveltejs/kit`, add `pnpm` override for `postcss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@playwright/test": "1.58.2",
 		"@sveltejs/adapter-auto": "7.0.1",
 		"@sveltejs/adapter-static": "3.0.10",
-		"@sveltejs/kit": "2.55.0",
+		"@sveltejs/kit": "2.57.1",
 		"@sveltejs/vite-plugin-svelte": "3.1.2",
 		"@types/eslint": "9.6.1",
 		"@types/jsdom": "28.0.1",
@@ -86,7 +86,8 @@
 			"svelte-preprocess"
 		],
 		"overrides": {
-			"flatted@<=3.4.1": ">=3.4.2"
+			"flatted@<=3.4.1": ">=3.4.2",
+			"postcss@<8.5.10": ">=8.5.10"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@sveltejs/vite-plugin-svelte": "3.1.2",
 		"@types/eslint": "9.6.1",
 		"@types/jsdom": "28.0.1",
+		"@types/node": "25.6.0",
 		"eslint": "9.39.4",
 		"eslint-plugin-svelte": "3.17.0",
 		"gh-pages": "6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@types/jsdom':
         specifier: 28.0.1
         version: 28.0.1
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
       eslint:
         specifier: 9.39.4
         version: 9.39.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   flatted@<=3.4.1: '>=3.4.2'
+  postcss@<8.5.10: '>=8.5.10'
 
 importers:
 
@@ -25,13 +26,13 @@ importers:
         version: 1.58.2
       '@sveltejs/adapter-auto':
         specifier: 7.0.1
-        version: 7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))
+        version: 7.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))
       '@sveltejs/adapter-static':
         specifier: 3.0.10
-        version: 3.0.10(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))
+        version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))
       '@sveltejs/kit':
-        specifier: 2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
+        specifier: 2.57.1
+        version: 2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: 3.1.2
         version: 3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
@@ -779,15 +780,15 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.55.0':
-    resolution: {integrity: sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==}
+  '@sveltejs/kit@2.57.1':
+    resolution: {integrity: sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
       '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      typescript: ^5.3.3
+      typescript: ^5.3.3 || ^6.0.0
       vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -2115,11 +2116,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2287,7 +2283,7 @@ packages:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       postcss:
@@ -2299,13 +2295,13 @@ packages:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.10'
 
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.4.29
+      postcss: '>=8.5.10'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -2313,10 +2309,6 @@ packages:
 
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2632,7 +2624,7 @@ packages:
       '@babel/core': ^7.10.2
       coffeescript: ^2.5.1
       less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
+      postcss: '>=8.5.10'
       postcss-load-config: '>=3'
       pug: ^3.0.0
       sass: ^1.26.8
@@ -3517,15 +3509,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))':
     dependencies:
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))':
     dependencies:
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))':
+  '@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
@@ -5055,8 +5047,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
@@ -5241,12 +5231,6 @@ snapshots:
   postcss@8.5.13:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5837,7 +5821,7 @@ snapshots:
   vite@5.4.21(@types/node@25.6.0)(sass@1.98.0)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.8
+      postcss: 8.5.13
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 25.6.0


### PR DESCRIPTION
## What does this change?

- Bumps version of `@sveltejs/kit` to `2.57.1`
- Adds `pnpm override` for `postcss` to ensure it uses at least version `8.5.10`
- Installs `@types/node`
