### PR TITLE
Revert "Bump urllib3 from 2.6.3 to 2.7.0 in /scripts/deploy"

### DIFF
--- a/scripts/deploy/Pipfile.lock
+++ b/scripts/deploy/Pipfile.lock
@@ -694,12 +694,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
-                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
-            "index": "pypi",
-            "markers": "python_version >= '3.10'",
-            "version": "==2.7.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.3"
         },
         "xmltodict": {
             "hashes": [


### PR DESCRIPTION
Reverts guardian/commercial-templates#629