### PR TITLE
fix template urls, and add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.idea

--- a/src/routes/(preview)/preview/[template]/+page.svelte
+++ b/src/routes/(preview)/preview/[template]/+page.svelte
@@ -20,12 +20,12 @@
 {#if adJson}
 	<div>
 		<a
-			href={`https://admanager.google.com/59666047#nativeStyles/nativeStyle/detail/${adJson?.nativeStyleId}?tab=preview`}
+			href={`https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=${adJson?.nativeStyleId}&tab=style_ad`}
 			>Prod Native Style</a
 		>
 		<br />
 		<a
-			href={`https://admanager.google.com/59666047#nativeStyles/nativeStyle/detail/${adJson?.testNativeStyleId}?tab=preview`}
+			href={`https://admanager.google.com/59666047#creatives/native/native_style/detail/style_id=${adJson?.testNativeStyleId}&tab=style_ad`}
 			>Test Native Style</a
 		>
 		<br />


### PR DESCRIPTION
## What does this change?
This pull request updates the Ad Manager preview links for native style details. 

The previous urls were redirecting to home. It seems like GAM changed the routes for the native styles.

They now take you to the correct tab and format in Ad Manager.

It also adds `.idea` to the `.gitignore` for intellij 
