### PR TITLE
Add Chromatic trial workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,71 @@
+name: Chromatic
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    name: Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          fetch-depth: 0
+
+      - run: corepack enable
+        shell: bash
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        shell: bash
+
+      - name: Check Chromatic project token
+        id: chromatic-token
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: |
+          if [[ -n "$CHROMATIC_PROJECT_TOKEN" ]]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to Chromatic
+        if: ${{ steps.chromatic-token.outputs.configured == 'true' }}
+        uses: chromaui/action@4a45535b6910c0b99226ebcb7648faf88fb1ee2e # v18.0.1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          autoAcceptChanges: main
+          onlyChanged: true
+          exitOnceUploaded: true
+          exitZeroOnChanges: true
+          buildScriptName: storybook:build
+
+      - name: Chromatic project token not configured
+        if: ${{ steps.chromatic-token.outputs.configured != 'true' }}
+        run: echo 'Skipping Chromatic until the CHROMATIC_PROJECT_TOKEN secret is added.'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ reload automatically. [Read more about Svelte templates in `src/templates/`][t]
 
 This repository has visual regression testing to help prevent the introduction of visual changes or bugs into the templates. The tests work by checking the templates on a local version of the dev site, which will include any changes on that branch, against the templates as they currently are on the main branch, on the GitHub pages site.
 
+### Storybook and Chromatic trial
+
+Chromatic runs alongside the existing Playwright tests during the trial. It
+publishes Storybook on pull requests and pushes to `main`, using TurboSnap to test
+only stories affected by a change. Visual changes do not fail the workflow during
+the trial and can be reviewed in the Chromatic UI.
+
+Run Storybook locally with:
+
+```bash
+pnpm storybook
+```
+
+Publishing locally requires the project token to be available as the
+`CHROMATIC_PROJECT_TOKEN` environment variable:
+
+```bash
+pnpm chromatic
+```
+
 ### Running the tests
 
 On each PR, visual regression testing is automatically triggered to check the code changes don't have any inadvertent effects on the design of the templates. You can run these tests locally using one of the following commands. Adding the `--ui` suffix will open a UI that you can use to run the tests, which can be useful when debugging.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"dev": "vite dev --port 7777",
 		"storybook": "storybook dev -p 6006",
 		"storybook:build": "storybook build",
-		"chromatic": "chromatic",
+		"chromatic": "chromatic --build-script-name=storybook:build --exit-zero-on-changes",
 		"build:preview": "vite build && touch build/.nojekyll",
 		"build:template:capi-multiple-hosted": "BUILD_TEMPLATE=capi-multiple-hosted REPLACE_GAM_VARS=true vite build",
 		"build:template:capi-multiple-paidfor": "BUILD_TEMPLATE=capi-multiple-paidfor REPLACE_GAM_VARS=true vite build",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a Chromatic workflow to publish Storybook and run visual regression tests alongside the existing Playwright tests.

Following the [established `dotcom-rendering` pattern](https://github.com/guardian/dotcom-rendering/blob/main/.github/workflows/dcr-chromatic.yml), the workflow checks out the full git history for accurate baselines, uses TurboSnap to test only affected stories, and auto-accepts changes on main. Visual changes are kept non-blocking during the trial, and the process skips cleanly if the CHROMATIC_PROJECT_TOKEN is unconfigured. Finally, it updates the local Chromatic command and documents how to run both Storybook and Chromatic.

See published stories [here](https://www.chromatic.com/build?appId=6a68b779992dc788e0cb14f4) 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216959658779076