### PR TITLE
Add Storybook stories for more templates

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,19 @@
+import { breakpoints } from '@guardian/source/foundations';
 import type { Preview } from '@storybook/sveltekit';
 import '../src/styles/global.scss';
 
 const preview: Preview = {
 	parameters: {
 		layout: 'fullscreen',
+		chromatic: {
+			viewports: [
+				360,
+				breakpoints.tablet,
+				breakpoints.desktop,
+				breakpoints.wide,
+				1600,
+			],
+		},
 	},
 };
 

--- a/src/lib/components/Fabric.stories.ts
+++ b/src/lib/components/Fabric.stories.ts
@@ -1,22 +1,11 @@
-import { breakpoints } from '@guardian/source/foundations';
 import type { Meta, StoryObj } from '@storybook/sveltekit';
 import { gamVariables } from '../../routes/templates/fabric/variables.gam';
+import { gamVariables as fabricXLGamVariables } from '../../routes/templates/fabric-xl/variables.gam';
 import Fabric from './Fabric.svelte';
 
 const meta = {
 	title: 'Templates/Fabric',
 	component: Fabric,
-	parameters: {
-		chromatic: {
-			viewports: [
-				360,
-				breakpoints.tablet,
-				breakpoints.desktop,
-				breakpoints.wide,
-				1600,
-			],
-		},
-	},
 	args: {
 		TrackingPixel: gamVariables.Trackingpixel,
 		ResearchPixel: gamVariables.Researchpixel,
@@ -50,3 +39,40 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const XL: Story = {
+	args: {
+		TrackingPixel: fabricXLGamVariables.TrackingPixel,
+		ResearchPixel: fabricXLGamVariables.ResearchPixel,
+		ViewabilityPixel: fabricXLGamVariables.ViewabilityPixel,
+		BackgroundScrollType: fabricXLGamVariables.BackgroundScrollType,
+		BackgroundColour: fabricXLGamVariables.BackgroundColour,
+		BackgroundImage: fabricXLGamVariables.BackgroundImage,
+		BackgroundImagePosition: fabricXLGamVariables.BackgroundImagePosition,
+		BackgroundImageRepeat: fabricXLGamVariables.BackgroundImageRepeat,
+		Layer1BackgroundImage: fabricXLGamVariables.Layer1BackgroundImage,
+		Layer1BackgroundPosition: fabricXLGamVariables.Layer1BackgroundPosition,
+		Layer2BackgroundImage: fabricXLGamVariables.Layer2BackgroundImage,
+		Layer2BackgroundPosition: fabricXLGamVariables.Layer2BackgroundPosition,
+		Layer3BackgroundImage: fabricXLGamVariables.Layer3BackgroundImage,
+		Layer3BackgroundPosition: fabricXLGamVariables.Layer3BackgroundPosition,
+		MobileBackgroundImage: fabricXLGamVariables.MobileBackgroundImage,
+		MobileBackgroundImagePosition:
+			fabricXLGamVariables.MobileBackgroundImagePosition,
+		MobileBackgroundImageRepeat:
+			fabricXLGamVariables.MobileBackgroundImageRepeat,
+		MobileLayer1BackgroundImage:
+			fabricXLGamVariables.MobileLayer1BackgroundImage,
+		MobileLayer1BackgroundPosition:
+			fabricXLGamVariables.MobileLayer1BackgroundPosition,
+		MobileLayer2BackgroundImage:
+			fabricXLGamVariables.MobileLayer2BackgroundImage,
+		MobileLayer2BackgroundPosition:
+			fabricXLGamVariables.MobileLayer2BackgroundPosition,
+		MobileLayer3BackgroundImage:
+			fabricXLGamVariables.MobileLayer3BackgroundImage,
+		MobileLayer3BackgroundPosition:
+			fabricXLGamVariables.MobileLayer3BackgroundPosition,
+		isXL: true,
+	},
+};

--- a/src/routes/templates/image-native/ImageNative.stories.ts
+++ b/src/routes/templates/image-native/ImageNative.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import Page from './+page.svelte';
+import { gamVariables } from './variables.gam';
+
+const transparentPixel =
+	'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=#';
+
+const meta = {
+	title: 'Templates/Image Native',
+	component: Page,
+	args: {
+		data: {
+			...gamVariables,
+			TrackingPixel: transparentPixel,
+			ResearchPixel: transparentPixel,
+			ViewabilityTracker: transparentPixel,
+		},
+	},
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/routes/templates/manual-multiple/ManualMultiple.stories.ts
+++ b/src/routes/templates/manual-multiple/ManualMultiple.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import Page from './+page.svelte';
+import { gamVariables } from './variables.gam';
+
+const meta = {
+	title: 'Templates/Manual Multiple',
+	component: Page,
+	args: {
+		data: gamVariables,
+	},
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/routes/templates/manual-single/ManualSingle.stories.ts
+++ b/src/routes/templates/manual-single/ManualSingle.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/sveltekit';
+import Page from './+page.svelte';
+import { gamVariables } from './variables.gam';
+
+const meta = {
+	title: 'Templates/Manual Single',
+	component: Page,
+	args: {
+		data: gamVariables,
+	},
+} satisfies Meta<typeof Page>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds Storybook stories for Fabric XL, Manual Single, Manual Multiple and Image Native using their existing GAM test data.

The shared Chromatic viewport configuration has been moved into the Storybook preview config so all stories are tested at the same widths.

Image Native uses an inline transparent tracking pixel because its unreplaced GAM cache buster causes a Vite error in Storybook. This only affects the story and does not change production behaviour.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?


